### PR TITLE
Use absolute import paths everywhere.

### DIFF
--- a/bibliopixel/animation.py
+++ b/bibliopixel/animation.py
@@ -1,14 +1,8 @@
-import time
-import log
+import threading, time
 
-from led import LEDMatrix
-from led import LEDStrip
-from led import LEDCircle
-import colors
-
-from util import d
-
-import threading
+from . led import LEDMatrix, LEDStrip, LEDCircle
+from . import colors, log
+from . util import d
 
 
 class animThread(threading.Thread):

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -1,4 +1,4 @@
-from spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder
 
 
 class DriverAPA102(DriverSPIBase):

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -1,4 +1,4 @@
-from spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder
 
 
 class DriverLPD8806(DriverSPIBase):

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -1,4 +1,4 @@
-from spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder
 import os
 from .. import gamma
 

--- a/bibliopixel/drivers/dummy_driver.py
+++ b/bibliopixel/drivers/dummy_driver.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase
+from . driver_base import DriverBase
 import time
 
 

--- a/bibliopixel/drivers/hue.py
+++ b/bibliopixel/drivers/hue.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase
+from . driver_base import DriverBase
 from .. import log
 
 try:

--- a/bibliopixel/drivers/image_sequence.py
+++ b/bibliopixel/drivers/image_sequence.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase
+from . driver_base import DriverBase
 import os
 import sys
 from .. import log

--- a/bibliopixel/drivers/network.py
+++ b/bibliopixel/drivers/network.py
@@ -1,11 +1,7 @@
-from driver_base import DriverBase
-import socket
-import sys
-import time
+import socket, sys, time, os
 
-import os
-os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import log
+from . driver_base import DriverBase
+from .. import log
 
 
 class CMDTYPE:

--- a/bibliopixel/drivers/network_receiver.py
+++ b/bibliopixel/drivers/network_receiver.py
@@ -1,10 +1,10 @@
 import threading
 import os
 import SocketServer
-from network import CMDTYPE, RETURN_CODES
+from . network import CMDTYPE, RETURN_CODES
 
 os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import log
+from .. import log
 
 
 class ThreadedDataHandler(SocketServer.BaseRequestHandler):

--- a/bibliopixel/drivers/serial_driver.py
+++ b/bibliopixel/drivers/serial_driver.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase, ChannelOrder
+from . driver_base import DriverBase, ChannelOrder
 import sys
 import time
 import os

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase, ChannelOrder
+from . driver_base import DriverBase, ChannelOrder
 import time
 
 import os

--- a/bibliopixel/drivers/visualizer.py
+++ b/bibliopixel/drivers/visualizer.py
@@ -1,11 +1,6 @@
-import time
+import time, os, platform, subprocess, math
 
-import os
-import platform
-import subprocess
-from network import DriverNetwork, socket
-import math
-
+from . network import DriverNetwork, socket
 from .. import log
 
 
@@ -44,8 +39,9 @@ class DriverVisualizer(DriverNetwork):
                 exe_string = "python"
                 suffix = "&"
 
-            dname = os.path.dirname(os.path.abspath(__file__))
-            script = '{}/visualizerUI.py'.format(dname)
+            dname = os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.abspath(__file__))))
+            script = os.path.join(dname, 'visualizer.py')
 
             if allip:
                 ip = "--allip"

--- a/bibliopixel/drivers/visualizerUI.py
+++ b/bibliopixel/drivers/visualizerUI.py
@@ -6,10 +6,9 @@ import sys
 import SocketServer
 import platform
 import os
-os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import log
+from .. import log
 
-from network_receiver import ThreadedDataServer, ThreadedDataHandler
+from . network_receiver import ThreadedDataServer, ThreadedDataHandler
 
 
 class VisualizerUI:
@@ -183,7 +182,7 @@ class VisualizerUI:
         self.layoutPixels()
         # self._master.after_idle(self.__handleResize)
 
-if __name__ == '__main__':
+def main():
     import argparse
     parser = argparse.ArgumentParser(description='BiblioPixel Visualizer')
     parser.add_argument('--width', help='Matrix Width',

--- a/bibliopixel/gamepad.py
+++ b/bibliopixel/gamepad.py
@@ -1,4 +1,4 @@
-from util import d
+from . util import d
 
 
 class BaseGamePad(object):

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python
-import colors
-import time
-import math
-import font
-import threading
-
+import math, threading, time
+from . import colors, font
 
 class updateThread(threading.Thread):
 

--- a/bibliopixel/serial_gamepad.py
+++ b/bibliopixel/serial_gamepad.py
@@ -6,7 +6,7 @@ except ImportError as e:
     raise ImportError(error)
 
 from distutils.version import LooseVersion
-from util import d
+from . util import d
 from gamepad import BaseGamePad
 import log
 

--- a/bibliopixel/win_gamepad_emu.py
+++ b/bibliopixel/win_gamepad_emu.py
@@ -1,7 +1,7 @@
 import win32api
 import win32con
 
-from util import d
+from . util import d
 from gamepad import BaseGamePad
 
 DEFAULT_MAP = {

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,0 +1,5 @@
+#!/bin/env/python
+
+if __name__ == '__main__':
+    from bibliopixel.drivers import visualizerUI
+    visualizerUI.main()


### PR DESCRIPTION
* Prepare for Python 3.x.
* Works in Python 2.7.

I was actually able to run a test script with a visualizer only with this under Python 3!  Further testing is required...