### PR TITLE
Triplets!

### DIFF
--- a/bibliopixel/animation.py
+++ b/bibliopixel/animation.py
@@ -66,7 +66,7 @@ class BaseAnimation(object):
         self._exit(type, value, traceback)
         self.stopThread(wait=True)
         self._led.all_off()
-        self._led.update()
+        self._led.push_to_driver()
         self._led.waitForUpdate()
 
     def cleanup(self):
@@ -115,7 +115,7 @@ class BaseAnimation(object):
             self._led._frameGenTime = int(mid - start)
             self._led._frameTotalTime = sleep
 
-            self._led.update()
+            self._led.push_to_driver()
             now = self._msTime()
 
             if self.animComplete and max_cycles > 0:

--- a/bibliopixel/animation.py
+++ b/bibliopixel/animation.py
@@ -318,8 +318,8 @@ class BaseStripAnim(BaseAnimation):
 
         self._start = max(start, 0)
         self._end = end
-        if self._end < 0 or self._end > self._led.lastIndex:
-            self._end = self._led.lastIndex
+        if self._end < 0 or self._end >= self._led.numLEDs:
+            self._end = self._led.numLEDs - 1
 
         self._size = self._end - self._start + 1
 

--- a/bibliopixel/animation.py
+++ b/bibliopixel/animation.py
@@ -1,14 +1,8 @@
-import time
-import log
+import threading, time
 
-from led import LEDMatrix
-from led import LEDStrip
-from led import LEDCircle
-import colors
-
-from util import d
-
-import threading
+from . led import LEDMatrix, LEDStrip, LEDCircle
+from . import colors, log
+from . util import d
 
 
 class animThread(threading.Thread):

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -4,9 +4,8 @@ from . spi_driver_base import DriverSPIBase, ChannelOrder
 class DriverAPA102(DriverSPIBase):
     """Main driver for APA102 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True, dev="/dev/spidev0.0", SPISpeed=2):
-        super(DriverAPA102, self).__init__(num, c_order=c_order,
-                                           use_py_spi=use_py_spi, dev=dev, SPISpeed=SPISpeed)
+    def __init__(self, num, **kwds):
+        super(DriverAPA102, self).__init__(num, **kwds)
 
         # APA102 requires latch bytes at the end
         self._latchBytes = (int(num / 64.0) + 1)

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -10,8 +10,8 @@ class DriverAPA102(DriverSPIBase):
         # APA102 requires latch bytes at the end
         self._latchBytes = (int(num / 64.0) + 1)
 
-    def _write_colors_to_buffer(self, data):
-        super(DriverAPA102, self)._write_colors_to_buffer(data)
+    def _write_colors_to_buffer(self, colors, pos):
+        super(DriverAPA102, self)._write_colors_to_buffer(colors, pos)
 
         newBuf = [0xFF] * (self.bufByteCount() + self.numLEDs)
         newBuf[1::4] = self._buf[0::3]

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -12,11 +12,11 @@ class DriverAPA102(DriverSPIBase):
 
     def _fixData(self, data):
         gamma = self.gamma
-        self._buf[:] = [0] * self.bufByteCount
+        self._buf[:] = [0] * self.bufByteCount()
         for a, b in enumerate(self.c_order):
             self._buf[a:self.numLEDs * 3:3] = [gamma[v] for v in data[b::3]]
 
-        newBuf = [0xFF] * (self.bufByteCount + self.numLEDs)
+        newBuf = [0xFF] * (self.bufByteCount() + self.numLEDs)
         newBuf[1::4] = self._buf[0::3]
         newBuf[2::4] = self._buf[1::3]
         newBuf[3::4] = self._buf[2::3]

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -11,10 +11,7 @@ class DriverAPA102(DriverSPIBase):
         self._latchBytes = (int(num / 64.0) + 1)
 
     def _write_colors_to_buffer(self, data):
-        gamma = self.gamma
-        self._buf[:] = bytearray(self.bufByteCount())
-        for a, b in enumerate(self.c_order):
-            self._buf[a:self.numLEDs * 3:3] = [gamma[v] for v in data[b::3]]
+        super(DriverAPA102, self)._write_colors_to_buffer(data)
 
         newBuf = [0xFF] * (self.bufByteCount() + self.numLEDs)
         newBuf[1::4] = self._buf[0::3]

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -10,9 +10,9 @@ class DriverAPA102(DriverSPIBase):
         # APA102 requires latch bytes at the end
         self._latchBytes = (int(num / 64.0) + 1)
 
-    def _fixData(self, data):
+    def _write_colors_to_buffer(self, data):
         gamma = self.gamma
-        self._buf[:] = [0] * self.bufByteCount()
+        self._buf[:] = bytearray(self.bufByteCount())
         for a, b in enumerate(self.c_order):
             self._buf[a:self.numLEDs * 3:3] = [gamma[v] for v in data[b::3]]
 

--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -1,4 +1,4 @@
-from spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder
 
 
 class DriverAPA102(DriverSPIBase):

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -19,9 +19,6 @@ class DriverLPD8806(DriverSPIBase):
 
     # LPD8806 requires gamma correction and only supports 7-bits per channel
     # running each value through gamma will fix all of this.
-    # def _write_colors_to_buffer(self, data):
-    #    for a, b in enumerate(self.c_order):
-    #        self._buf[a:self.numLEDs*3:3] = [self.gamma[v] for v in data[b::3]]
 
 MANIFEST = [
     {

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -19,7 +19,7 @@ class DriverLPD8806(DriverSPIBase):
 
     # LPD8806 requires gamma correction and only supports 7-bits per channel
     # running each value through gamma will fix all of this.
-    # def _fixData(self, data):
+    # def _write_colors_to_buffer(self, data):
     #    for a, b in enumerate(self.c_order):
     #        self._buf[a:self.numLEDs*3:3] = [self.gamma[v] for v in data[b::3]]
 

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -4,9 +4,8 @@ from . spi_driver_base import DriverSPIBase, ChannelOrder
 class DriverLPD8806(DriverSPIBase):
     """Main driver for LPD8806 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True, dev="/dev/spidev0.0", SPISpeed=2):
-        super(DriverLPD8806, self).__init__(num, c_order=c_order,
-                                            use_py_spi=use_py_spi, dev=dev, SPISpeed=SPISpeed)
+    def __init__(self, num, **kwds):
+        super(DriverLPD8806, self).__init__(num, **kwds)
 
         # Color calculations from
         # http://learn.adafruit.com/light-painting-with-raspberry-pi
@@ -14,7 +13,7 @@ class DriverLPD8806(DriverSPIBase):
             pow(float(i) / 255.0, 2.5) * 127.0 + 0.5) for i in range(256)]
 
         # LPD8806 requires latch bytes at the end
-        self._latchBytes = (self.numLEDs + 31) / 32
+        self._latchBytes = (self.numLEDs + 31) // 32
         for i in range(0, self._latchBytes):
             self._buf.append(0)
 

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -1,4 +1,4 @@
-from spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder
 
 
 class DriverLPD8806(DriverSPIBase):

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -6,12 +6,11 @@ from .. import gamma
 class DriverWS2801(DriverSPIBase):
     """Main driver for WS2801 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True, dev="/dev/spidev0.0", SPISpeed=1):
+    def __init__(self, num, SPISpeed=1, **kwds):
         if SPISpeed > 1 or SPISpeed <= 0:
             raise ValueError(
                 "WS2801 requires an SPI speed no greater than 1MHz or SPI speed was set <= 0")
-        super(DriverWS2801, self).__init__(num, c_order=c_order,
-                                           use_py_spi=use_py_spi, dev=dev, SPISpeed=SPISpeed)
+        super(DriverWS2801, self).__init__(num, SPISpeed=SPISpeed, **kwds)
 
         self.gamma = gamma.WS2801
 

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -14,12 +14,6 @@ class DriverWS2801(DriverSPIBase):
 
         self.gamma = gamma.WS2801
 
-    # WS2801 requires gamma correction so we run it through gamma as the
-    # channels are ordered
-    def _write_colors_to_buffer(self, data):
-        for a, b in enumerate(self.c_order):
-            self._buf[a:self.numLEDs * 3:3] = [self.gamma[v]
-                                               for v in data[b::3]]
 
 MANIFEST = [
     {

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -1,4 +1,4 @@
-from spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder
 import os
 from .. import gamma
 

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -16,7 +16,7 @@ class DriverWS2801(DriverSPIBase):
 
     # WS2801 requires gamma correction so we run it through gamma as the
     # channels are ordered
-    def _fixData(self, data):
+    def _write_colors_to_buffer(self, data):
         for a, b in enumerate(self.c_order):
             self._buf[a:self.numLEDs * 3:3] = [self.gamma[v]
                                                for v in data[b::3]]

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -45,13 +45,13 @@ class DriverBase(object):
         return 3 * self.numLEDs
 
     # Push new data to strand
-    def update(self, data):
+    def _receive_colors(self, data):
         # TODO: use abc here.
         raise RuntimeError("Base class receive_colors() called.")
 
     def receive_colors(self, data):
         start = time.time() * 1000.0
-        self.update(data)
+        self._receive_colors(data)
         if self._thread:
             self.lastUpdate = (time.time() * 1000.0) - start
 

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -59,6 +59,6 @@ class DriverBase(object):
         return False
 
     def _write_colors_to_buffer(self, data):
-        gamma = self.gamma
+        gamma, numLEDs = self.gamma, self.numLEDs
         for a, b in enumerate(self.c_order):
-            self._buf[a:self.numLEDs * 3:3] = [gamma[v] for v in data[b::3]]
+            self._buf[a:numLEDs * 3:3] = [gamma[v] for v in data[b::3]]

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -27,7 +27,7 @@ class DriverBase(object):
 
         self.width = width
         self.height = height
-        self._buf = [0] * self.bufByteCount()
+        self._buf = bytearray(self.bufByteCount())
 
         self._thread = None
         self.lastUpdate = 0
@@ -58,7 +58,7 @@ class DriverBase(object):
     def setMasterBrightness(self, brightness):
         return False
 
-    def _fixData(self, data):
+    def _write_colors_to_buffer(self, data):
         gamma = self.gamma
         for a, b in enumerate(self.c_order):
             self._buf[a:self.numLEDs * 3:3] = [gamma[v] for v in data[b::3]]

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -61,6 +61,6 @@ class DriverBase(object):
     def _write_colors_to_buffer(self, colors, pos):
         gamma, (r, g, b) = self.gamma, self.c_order
         for i in range(self.numLEDs):
-            c = colors[i + pos]
-            self._buf[i * 3:(i + 1) * 3] = (
-                int(gamma[c[r]]), int(gamma[c[g]]), int(gamma[c[b]]))
+            fix = lambda x: gamma[max(0, min(255, int(x)))]
+            c = tuple(int(x) for x in colors[i + pos])
+            self._buf[i * 3:(i + 1) * 3] = fix(c[r]), fix(c[g]), fix(c[b])

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -62,4 +62,5 @@ class DriverBase(object):
         gamma, (r, g, b) = self.gamma, self.c_order
         for i in range(self.numLEDs):
             c = colors[i + pos]
-            self._buf[i * 3:(i + 1) * 3] = gamma[c[r]], gamma[c[g]], gamma[c[b]]
+            self._buf[i * 3:(i + 1) * 3] = (
+                int(gamma[c[r]]), int(gamma[c[g]]), int(gamma[c[b]]))

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -27,8 +27,7 @@ class DriverBase(object):
 
         self.width = width
         self.height = height
-        self.bufByteCount = int(3 * self.numLEDs)
-        self._buf = [0] * self.bufByteCount
+        self._buf = [0] * self.bufByteCount()
 
         self._thread = None
         self.lastUpdate = 0
@@ -41,6 +40,9 @@ class DriverBase(object):
 
     def cleanup(self):
         return self.__exit__(None, None, None)
+
+    def bufByteCount(self):
+        return 3 * self.numLEDs
 
     # Push new data to strand
     def update(self, data):

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -9,6 +9,8 @@ class ChannelOrder:
     BRG = 2, 0, 1
     BGR = 2, 1, 0
 
+    ORDERS = RGB, RBG, GRB, GBR, BRG, BGR
+
 
 class DriverBase(object):
     """Base driver class to build other drivers from"""
@@ -24,6 +26,7 @@ class DriverBase(object):
         self.gamma = gamma or range(256)
 
         self.c_order = c_order
+        self.perm = ChannelOrder.ORDERS.index(c_order)
 
         self.width = width
         self.height = height

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -2,12 +2,12 @@ import time
 
 
 class ChannelOrder:
-    RGB = [0, 1, 2]
-    RBG = [0, 2, 1]
-    GRB = [1, 0, 2]
-    GBR = [1, 2, 0]
-    BRG = [2, 0, 1]
-    BGR = [2, 1, 0]
+    RGB = 0, 1, 2
+    RBG = 0, 2, 1
+    GRB = 1, 0, 2
+    GBR = 1, 2, 0
+    BRG = 2, 0, 1
+    BGR = 2, 1, 0
 
 
 class DriverBase(object):
@@ -45,20 +45,21 @@ class DriverBase(object):
         return 3 * self.numLEDs
 
     # Push new data to strand
-    def _receive_colors(self, data):
+    def _receive_colors(self, colors, pos):
         # TODO: use abc here.
         raise RuntimeError("Base class receive_colors() called.")
 
-    def receive_colors(self, data):
+    def receive_colors(self, colors, pos):
         start = time.time() * 1000.0
-        self._receive_colors(data)
+        self._receive_colors(colors, pos)
         if self._thread:
             self.lastUpdate = (time.time() * 1000.0) - start
 
     def setMasterBrightness(self, brightness):
         return False
 
-    def _write_colors_to_buffer(self, data):
-        gamma, numLEDs = self.gamma, self.numLEDs
-        for a, b in enumerate(self.c_order):
-            self._buf[a:numLEDs * 3:3] = [gamma[v] for v in data[b::3]]
+    def _write_colors_to_buffer(self, colors, pos):
+        gamma, (r, g, b) = self.gamma, self.c_order
+        for i in range(self.numLEDs):
+            c = colors[i + pos]
+            self._buf[i * 3:(i + 1) * 3] = gamma[c[r]], gamma[c[g]], gamma[c[b]]

--- a/bibliopixel/drivers/driver_base.py
+++ b/bibliopixel/drivers/driver_base.py
@@ -46,9 +46,10 @@ class DriverBase(object):
 
     # Push new data to strand
     def update(self, data):
-        raise RuntimeError("Base class update() called. This shouldn't happen")
+        # TODO: use abc here.
+        raise RuntimeError("Base class receive_colors() called.")
 
-    def _update(self, data):
+    def receive_colors(self, data):
         start = time.time() * 1000.0
         self.update(data)
         if self._thread:

--- a/bibliopixel/drivers/driver_test.py
+++ b/bibliopixel/drivers/driver_test.py
@@ -10,10 +10,10 @@ def mock_open(self, fname, perm='r'):
     pass #
 
 class DriverTest(unittest.TestCase):
-    COLORS = [0, 0, 0,
-              1, 8, 64,
-              2, 16, 128,
-              3, 24, 192]
+    COLORS = [(0, 0, 0),
+              (1, 8, 64),
+              (2, 16, 128),
+              (3, 24, 192)]
 
     SPD = dict(use_py_spi=False, open=mock_open)
 
@@ -22,40 +22,41 @@ class DriverTest(unittest.TestCase):
         for i in range(len(driver._buf)):
            driver._buf[i] = 23  # randomize
         self.assertTrue(all(driver._buf))
-        driver._write_colors_to_buffer([0, 0, 0] * 4)
+        driver._write_colors_to_buffer([(0, 0, 0)] * 4, 0)
         self.assertFalse(any(driver._buf))  # It wrote zeroes!
 
     def test_simple(self):
         driver = DriverBase(num=4)
-        driver._write_colors_to_buffer(self.COLORS)
-        self.assertEqual(list(driver._buf), self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
+        self.assertEqual(list(driver._buf),
+                         [0, 0, 0, 1, 8, 64, 2, 16, 128, 3, 24, 192])
 
     def test_permute(self):
         driver = DriverBase(num=4, c_order=ChannelOrder.GRB)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 8, 1, 64, 16, 2, 128, 24, 3, 192])
 
         driver = DriverBase(num=4, c_order=ChannelOrder.BRG)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 64, 1, 8, 128, 2, 16, 192, 3, 24])
 
     def test_gamma(self):
         driver = DriverBase(num=4, gamma=gamma.LPD8806)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
 
         driver = DriverBase(num=4, c_order=ChannelOrder.RGB,
                             gamma=gamma.LPD8806)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
 
     def test_apa102(self):
         driver = DriverAPA102(num=4, **self.SPD)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0,
                           0, 255, 0,
@@ -68,7 +69,7 @@ class DriverTest(unittest.TestCase):
 
     def test_lpd8806(self):
         driver = DriverLPD8806(num=4, **self.SPD)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                              [128, 128, 128,
                               128, 128, 132,
@@ -77,7 +78,7 @@ class DriverTest(unittest.TestCase):
 
     def test_ws2801(self):
         driver = DriverWS2801(num=4, **self.SPD)
-        driver._write_colors_to_buffer(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS, 0)
         self.assertEqual(list(driver._buf),
                         [0, 0, 0, 0, 0, 8, 0, 0, 45, 0, 0, 125])
 

--- a/bibliopixel/drivers/driver_test.py
+++ b/bibliopixel/drivers/driver_test.py
@@ -22,40 +22,40 @@ class DriverTest(unittest.TestCase):
         for i in range(len(driver._buf)):
            driver._buf[i] = 23  # randomize
         self.assertTrue(all(driver._buf))
-        driver._fixData([0, 0, 0] * 4)
+        driver._write_colors_to_buffer([0, 0, 0] * 4)
         self.assertFalse(any(driver._buf))  # It wrote zeroes!
 
     def test_simple(self):
         driver = DriverBase(num=4)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf), self.COLORS)
 
     def test_permute(self):
         driver = DriverBase(num=4, c_order=ChannelOrder.GRB)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 8, 1, 64, 16, 2, 128, 24, 3, 192])
 
         driver = DriverBase(num=4, c_order=ChannelOrder.BRG)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 64, 1, 8, 128, 2, 16, 192, 3, 24])
 
     def test_gamma(self):
         driver = DriverBase(num=4, gamma=gamma.LPD8806)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
 
         driver = DriverBase(num=4, c_order=ChannelOrder.RGB,
                             gamma=gamma.LPD8806)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
 
     def test_apa102(self):
         driver = DriverAPA102(num=4, **self.SPD)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                          [0, 0, 0,
                           0, 255, 0,
@@ -68,7 +68,7 @@ class DriverTest(unittest.TestCase):
 
     def test_lpd8806(self):
         driver = DriverLPD8806(num=4, **self.SPD)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                              [128, 128, 128,
                               128, 128, 132,
@@ -77,7 +77,7 @@ class DriverTest(unittest.TestCase):
 
     def test_ws2801(self):
         driver = DriverWS2801(num=4, **self.SPD)
-        driver._fixData(self.COLORS)
+        driver._write_colors_to_buffer(self.COLORS)
         self.assertEqual(list(driver._buf),
                         [0, 0, 0, 0, 0, 8, 0, 0, 45, 0, 0, 125])
 

--- a/bibliopixel/drivers/driver_test.py
+++ b/bibliopixel/drivers/driver_test.py
@@ -28,59 +28,59 @@ class DriverTest(unittest.TestCase):
     def test_simple(self):
         driver = DriverBase(num=4)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                         [0, 0, 0, 1, 8, 64, 2, 16, 128, 3, 24, 192])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0, 1, 8, 64, 2, 16, 128, 3, 24, 192]))
 
     def test_permute(self):
         driver = DriverBase(num=4, c_order=ChannelOrder.GRB)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                         [0, 0, 0, 8, 1, 64, 16, 2, 128, 24, 3, 192])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0, 8, 1, 64, 16, 2, 128, 24, 3, 192]))
 
         driver = DriverBase(num=4, c_order=ChannelOrder.BRG)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                         [0, 0, 0, 64, 1, 8, 128, 2, 16, 192, 3, 24])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0, 64, 1, 8, 128, 2, 16, 192, 3, 24]))
 
     def test_gamma(self):
         driver = DriverBase(num=4, gamma=gamma.LPD8806)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                         [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125]))
 
         driver = DriverBase(num=4, c_order=ChannelOrder.RGB,
                             gamma=gamma.LPD8806)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                         [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125]))
 
     def test_apa102(self):
         driver = DriverAPA102(num=4, **self.SPD)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                         [0, 0, 0,
-                          0, 255, 0,
-                          0, 0, 255,
-                          8, 1, 64,
-                          255, 16, 2,
-                          128, 255, 24,
-                          3, 192, 255,
-                          0, 0, 0])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0,
+             0, 255, 0,
+             0, 0, 255,
+             8, 1, 64,
+             255, 16, 2,
+             128, 255, 24,
+             3, 192, 255,
+             0, 0, 0]))
 
     def test_lpd8806(self):
         driver = DriverLPD8806(num=4, **self.SPD)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                             [128, 128, 128,
-                              128, 128, 132,
-                              128, 128, 151,
-                              128, 128, 190, 0])
+        self.assertEqual(driver._buf, bytearray(
+                         [128, 128, 128,
+                          128, 128, 132,
+                          128, 128, 151,
+                          128, 128, 190, 0]))
 
     def test_ws2801(self):
         driver = DriverWS2801(num=4, **self.SPD)
         driver._write_colors_to_buffer(self.COLORS, 0)
-        self.assertEqual(list(driver._buf),
-                        [0, 0, 0, 0, 0, 8, 0, 0, 45, 0, 0, 125])
+        self.assertEqual(driver._buf, bytearray(
+            [0, 0, 0, 0, 0, 8, 0, 0, 45, 0, 0, 125]))
 
     def test_tdsp(self):
         try:

--- a/bibliopixel/drivers/driver_test.py
+++ b/bibliopixel/drivers/driver_test.py
@@ -1,0 +1,89 @@
+import unittest
+
+from .. import gamma
+from . driver_base import DriverBase, ChannelOrder
+from . APA102 import DriverAPA102
+from . LPD8806 import DriverLPD8806
+from . WS2801 import DriverWS2801
+
+def mock_open(self, fname, perm='r'):
+    pass #
+
+class DriverTest(unittest.TestCase):
+    COLORS = [0, 0, 0,
+              1, 8, 64,
+              2, 16, 128,
+              3, 24, 192]
+
+    SPD = dict(use_py_spi=False, open=mock_open)
+
+    def test_trivial(self):
+        driver = DriverBase(num=4)
+        for i in range(len(driver._buf)):
+           driver._buf[i] = 23  # randomize
+        self.assertTrue(all(driver._buf))
+        driver._fixData([0, 0, 0] * 4)
+        self.assertFalse(any(driver._buf))  # It wrote zeroes!
+
+    def test_simple(self):
+        driver = DriverBase(num=4)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf), self.COLORS)
+
+    def test_permute(self):
+        driver = DriverBase(num=4, c_order=ChannelOrder.GRB)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                         [0, 0, 0, 8, 1, 64, 16, 2, 128, 24, 3, 192])
+
+        driver = DriverBase(num=4, c_order=ChannelOrder.BRG)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                         [0, 0, 0, 64, 1, 8, 128, 2, 16, 192, 3, 24])
+
+    def test_gamma(self):
+        driver = DriverBase(num=4, gamma=gamma.LPD8806)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                         [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
+
+        driver = DriverBase(num=4, c_order=ChannelOrder.RGB,
+                            gamma=gamma.LPD8806)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                         [0, 0, 0, 0, 0, 8, 0, 0, 46, 0, 1, 125])
+
+    def test_apa102(self):
+        driver = DriverAPA102(num=4, **self.SPD)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                         [0, 0, 0,
+                          0, 255, 0,
+                          0, 0, 255,
+                          8, 1, 64,
+                          255, 16, 2,
+                          128, 255, 24,
+                          3, 192, 255,
+                          0, 0, 0])
+
+    def test_lpd8806(self):
+        driver = DriverLPD8806(num=4, **self.SPD)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                             [128, 128, 128,
+                              128, 128, 132,
+                              128, 128, 151,
+                              128, 128, 190, 0])
+
+    def test_ws2801(self):
+        driver = DriverWS2801(num=4, **self.SPD)
+        driver._fixData(self.COLORS)
+        self.assertEqual(list(driver._buf),
+                        [0, 0, 0, 0, 0, 8, 0, 0, 45, 0, 0, 125])
+
+    def test_tdsp(self):
+        try:
+            import tdsp
+        except:
+            self.assertTrue(True)
+            return

--- a/bibliopixel/drivers/dummy_driver.py
+++ b/bibliopixel/drivers/dummy_driver.py
@@ -11,7 +11,7 @@ class DriverDummy(DriverBase):
         self._delay = delay
 
     # Push new data to strand
-    def _receive_colors(self, data):
+    def _receive_colors(self, colors, pos):
         if self._delay > 0:
             time.sleep(self._delay / 1000.0)
         else:

--- a/bibliopixel/drivers/dummy_driver.py
+++ b/bibliopixel/drivers/dummy_driver.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase
+from . driver_base import DriverBase
 import time
 
 

--- a/bibliopixel/drivers/dummy_driver.py
+++ b/bibliopixel/drivers/dummy_driver.py
@@ -11,7 +11,7 @@ class DriverDummy(DriverBase):
         self._delay = delay
 
     # Push new data to strand
-    def update(self, data):
+    def _receive_colors(self, data):
         if self._delay > 0:
             time.sleep(self._delay / 1000.0)
         else:

--- a/bibliopixel/drivers/hue.py
+++ b/bibliopixel/drivers/hue.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase
+from . driver_base import DriverBase
 from .. import log
 
 try:

--- a/bibliopixel/drivers/hue.py
+++ b/bibliopixel/drivers/hue.py
@@ -66,12 +66,9 @@ class DriverHue(DriverBase):
         s = int(self._mapRange(s, 0.0, 1.0, 0, 254))
         return (h, s)
 
-    def _receive_colors(self, data):
-        pixels = [tuple(data[(p * 3):(p * 3) + 3])
-                  for p in range(len(data) / 3)]
-
+    def _receive_colors(self, colors, pos):
         for i in range(len(self._ids)):
-            h, s = self._rgb2hs(pixels[i])
+            h, s = self._rgb2hs(colors[i + pos])
             bri = self._brightness
             if s == 0:
                 bri = 0

--- a/bibliopixel/drivers/hue.py
+++ b/bibliopixel/drivers/hue.py
@@ -66,7 +66,7 @@ class DriverHue(DriverBase):
         s = int(self._mapRange(s, 0.0, 1.0, 0, 254))
         return (h, s)
 
-    def update(self, data):
+    def _receive_colors(self, data):
         pixels = [tuple(data[(p * 3):(p * 3) + 3])
                   for p in range(len(data) / 3)]
 

--- a/bibliopixel/drivers/image_sequence.py
+++ b/bibliopixel/drivers/image_sequence.py
@@ -38,6 +38,7 @@ class DriverImageSequence(DriverBase):
                 else:
                     i = x
                 rgb = colors[i + pos]
+                # TODO: is it an issue that colors now are floats?
                 draw.rectangle([x * size, y * size, x * size +
                                 size - 1, y * size + size - 1], rgb, rgb)
 

--- a/bibliopixel/drivers/image_sequence.py
+++ b/bibliopixel/drivers/image_sequence.py
@@ -26,7 +26,7 @@ class DriverImageSequence(DriverBase):
             self.height = 1
 
     # Push new data to strand
-    def _receive_colors(self, data):
+    def _receive_colors(self, colors, pos):
         map = self.matrix_map
         size = self._pixelSize
         img = Image.new("RGB", (self.width * size, self.height * size), None)
@@ -37,7 +37,7 @@ class DriverImageSequence(DriverBase):
                     i = map[y][x]
                 else:
                     i = x
-                rgb = tuple(data[i * 3:i * 3 + 3])
+                rgb = colors[i + pos]
                 draw.rectangle([x * size, y * size, x * size +
                                 size - 1, y * size + size - 1], rgb, rgb)
 

--- a/bibliopixel/drivers/image_sequence.py
+++ b/bibliopixel/drivers/image_sequence.py
@@ -26,7 +26,7 @@ class DriverImageSequence(DriverBase):
             self.height = 1
 
     # Push new data to strand
-    def update(self, data):
+    def _receive_colors(self, data):
         map = self.matrix_map
         size = self._pixelSize
         img = Image.new("RGB", (self.width * size, self.height * size), None)

--- a/bibliopixel/drivers/image_sequence.py
+++ b/bibliopixel/drivers/image_sequence.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase
+from . driver_base import DriverBase
 import os
 import sys
 from .. import log

--- a/bibliopixel/drivers/network.py
+++ b/bibliopixel/drivers/network.py
@@ -52,7 +52,7 @@ class DriverNetwork(DriverBase):
             count = self.bufByteCount()
             packet = self._generateHeader(CMDTYPE.PIXEL_DATA, count)
             indexes = range(pos, pos + self.numLEDs)
-            packet.extend(c for i in indexes for c in colors[i])
+            packet.extend(int(c) for i in indexes for c in colors[i])
             s.sendall(packet)
 
             resp = ord(s.recv(1))

--- a/bibliopixel/drivers/network.py
+++ b/bibliopixel/drivers/network.py
@@ -45,15 +45,14 @@ class DriverNetwork(DriverBase):
             raise IOError(error)
 
     # Push new data to strand
-    def _receive_colors(self, data):
+    def _receive_colors(self, colors, pos):
         try:
             s = self._connect()
 
             count = self.bufByteCount()
             packet = self._generateHeader(CMDTYPE.PIXEL_DATA, count)
-
-            packet.extend(data)
-
+            indexes = range(pos, pos + self.numLEDs)
+            packet.extend(c for i in indexes for c in colors[i])
             s.sendall(packet)
 
             resp = ord(s.recv(1))

--- a/bibliopixel/drivers/network.py
+++ b/bibliopixel/drivers/network.py
@@ -45,7 +45,7 @@ class DriverNetwork(DriverBase):
             raise IOError(error)
 
     # Push new data to strand
-    def update(self, data):
+    def _receive_colors(self, data):
         try:
             s = self._connect()
 

--- a/bibliopixel/drivers/network.py
+++ b/bibliopixel/drivers/network.py
@@ -1,11 +1,7 @@
-from driver_base import DriverBase
-import socket
-import sys
-import time
+import socket, sys, time, os
 
-import os
-os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import log
+from . driver_base import DriverBase
+from .. import log
 
 
 class CMDTYPE:

--- a/bibliopixel/drivers/network.py
+++ b/bibliopixel/drivers/network.py
@@ -49,7 +49,7 @@ class DriverNetwork(DriverBase):
         try:
             s = self._connect()
 
-            count = self.bufByteCount
+            count = self.bufByteCount()
             packet = self._generateHeader(CMDTYPE.PIXEL_DATA, count)
 
             packet.extend(data)

--- a/bibliopixel/drivers/network_receiver.py
+++ b/bibliopixel/drivers/network_receiver.py
@@ -78,7 +78,7 @@ class NetworkReceiver:
         self.address = (interface, port)
         SocketServer.TCPServer.allow_reuse_address = True
         self._server = ThreadedDataServer(self.address, ThreadedDataHandler)
-        self._server.update = self._update
+        self._server.update = self.receive_colors
         self._server.setBrightness = self._led.setMasterBrightness
 
     def start(self, join=False):
@@ -95,6 +95,6 @@ class NetworkReceiver:
         self._server.server_close()
         # self._t.join()
 
-    def _update(self, data):
+    def receive_colors(self, data):
         self._led.setBuffer(list(data))
         self._led.push_to_driver()

--- a/bibliopixel/drivers/network_receiver.py
+++ b/bibliopixel/drivers/network_receiver.py
@@ -97,4 +97,4 @@ class NetworkReceiver:
 
     def _update(self, data):
         self._led.setBuffer(list(data))
-        self._led.update()
+        self._led.push_to_driver()

--- a/bibliopixel/drivers/network_receiver.py
+++ b/bibliopixel/drivers/network_receiver.py
@@ -1,10 +1,10 @@
 import threading
 import os
 import SocketServer
-from network import CMDTYPE, RETURN_CODES
+from . network import CMDTYPE, RETURN_CODES
 
 os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import log
+from .. import log
 
 
 class ThreadedDataHandler(SocketServer.BaseRequestHandler):

--- a/bibliopixel/drivers/network_receiver.py
+++ b/bibliopixel/drivers/network_receiver.py
@@ -78,7 +78,7 @@ class NetworkReceiver:
         self.address = (interface, port)
         SocketServer.TCPServer.allow_reuse_address = True
         self._server = ThreadedDataServer(self.address, ThreadedDataHandler)
-        self._server.update = self.receive_colors
+        self._server.update = self.update
         self._server.setBrightness = self._led.setMasterBrightness
 
     def start(self, join=False):
@@ -95,6 +95,6 @@ class NetworkReceiver:
         self._server.server_close()
         # self._t.join()
 
-    def receive_colors(self, data):
+    def update(self, data):
         self._led.setBuffer(list(data))
         self._led.push_to_driver()

--- a/bibliopixel/drivers/serial_driver.py
+++ b/bibliopixel/drivers/serial_driver.py
@@ -316,7 +316,7 @@ class DriverSerial(DriverBase):
         count = self.bufByteCount() + self._bufPad
         packet = DriverSerial._generateHeader(CMDTYPE.PIXEL_DATA, count)
 
-        self._fixData(data)
+        self._write_colors_to_buffer(data)
 
         packet.extend(self._buf)
         packet.extend([0] * self._bufPad)

--- a/bibliopixel/drivers/serial_driver.py
+++ b/bibliopixel/drivers/serial_driver.py
@@ -312,11 +312,11 @@ class DriverSerial(DriverBase):
             return True
 
     # Push new data to strand
-    def _receive_colors(self, data):
+    def _receive_colors(self, colors, pos):
         count = self.bufByteCount() + self._bufPad
         packet = DriverSerial._generateHeader(CMDTYPE.PIXEL_DATA, count)
 
-        self._write_colors_to_buffer(data)
+        self._write_colors_to_buffer(colors, pos)
 
         packet.extend(self._buf)
         packet.extend([0] * self._bufPad)

--- a/bibliopixel/drivers/serial_driver.py
+++ b/bibliopixel/drivers/serial_driver.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase, ChannelOrder
+from . driver_base import DriverBase, ChannelOrder
 import sys
 import time
 import os

--- a/bibliopixel/drivers/serial_driver.py
+++ b/bibliopixel/drivers/serial_driver.py
@@ -215,7 +215,7 @@ class DriverSerial(DriverBase):
 
             packet = DriverSerial._generateHeader(CMDTYPE.SETUP_DATA, 4)
             packet.append(self._type)  # set strip type
-            byteCount = self.bufByteCount
+            byteCount = self.bufByteCount()
             if self._type in BufferChipsets:
                 if self._type == LEDTYPE.APA102 and self.devVer >= 2:
                     pass
@@ -313,7 +313,7 @@ class DriverSerial(DriverBase):
 
     # Push new data to strand
     def update(self, data):
-        count = self.bufByteCount + self._bufPad
+        count = self.bufByteCount() + self._bufPad
         packet = DriverSerial._generateHeader(CMDTYPE.PIXEL_DATA, count)
 
         self._fixData(data)

--- a/bibliopixel/drivers/serial_driver.py
+++ b/bibliopixel/drivers/serial_driver.py
@@ -312,7 +312,7 @@ class DriverSerial(DriverBase):
             return True
 
     # Push new data to strand
-    def update(self, data):
+    def _receive_colors(self, data):
         count = self.bufByteCount() + self._bufPad
         packet = DriverSerial._generateHeader(CMDTYPE.PIXEL_DATA, count)
 

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -8,7 +8,8 @@ from .. import log
 class DriverSPIBase(DriverBase):
     """Base driver for controling SPI devices on systems like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.GRB, use_py_spi=True, dev="/dev/spidev0.0", SPISpeed=2):
+    def __init__(self, num, c_order=ChannelOrder.GRB, use_py_spi=True,
+                 dev="/dev/spidev0.0", SPISpeed=2, open=open):
 
         super(DriverSPIBase, self).__init__(num, c_order=c_order)
 

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -77,5 +77,5 @@ class DriverSPIBase(DriverBase):
             self.spi.flush()
 
     def _receive_colors(self, data):
-        self._fixData(data)
+        self._write_colors_to_buffer(data)
         self._sendData()

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -76,6 +76,6 @@ class DriverSPIBase(DriverBase):
             self.spi.write(self._buf)
             self.spi.flush()
 
-    def update(self, data):
+    def _receive_colors(self, data):
         self._fixData(data)
         self._sendData()

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -1,4 +1,4 @@
-from driver_base import DriverBase, ChannelOrder
+from . driver_base import DriverBase, ChannelOrder
 import time
 
 import os

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -76,6 +76,6 @@ class DriverSPIBase(DriverBase):
             self.spi.write(self._buf)
             self.spi.flush()
 
-    def _receive_colors(self, data):
-        self._write_colors_to_buffer(data)
+    def _receive_colors(self, colors, pos):
+        self._write_colors_to_buffer(colors, pos)
         self._sendData()

--- a/bibliopixel/drivers/visualizer.py
+++ b/bibliopixel/drivers/visualizer.py
@@ -1,11 +1,6 @@
-import time
+import time, os, platform, subprocess, math
 
-import os
-import platform
-import subprocess
-from network import DriverNetwork, socket
-import math
-
+from . network import DriverNetwork, socket
 from .. import log
 
 
@@ -44,8 +39,9 @@ class DriverVisualizer(DriverNetwork):
                 exe_string = "python"
                 suffix = "&"
 
-            dname = os.path.dirname(os.path.abspath(__file__))
-            script = '{}/visualizerUI.py'.format(dname)
+            dname = os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.abspath(__file__))))
+            script = os.path.join(dname, 'visualizer.py')
 
             if allip:
                 ip = "--allip"

--- a/bibliopixel/drivers/visualizer.py
+++ b/bibliopixel/drivers/visualizer.py
@@ -33,10 +33,10 @@ class DriverVisualizer(DriverNetwork):
             if "windows" in operating_system:
                 exe_string = "start python"
             elif "darwin" in operating_system:
-                exe_string = "python"
+                exe_string = "python2.7"
                 suffix = "&"
             else:
-                exe_string = "python"
+                exe_string = "python2.7"
                 suffix = "&"
 
             dname = os.path.dirname(os.path.dirname(os.path.dirname(

--- a/bibliopixel/drivers/visualizerUI.py
+++ b/bibliopixel/drivers/visualizerUI.py
@@ -6,10 +6,9 @@ import sys
 import SocketServer
 import platform
 import os
-os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import log
+from .. import log
 
-from network_receiver import ThreadedDataServer, ThreadedDataHandler
+from . network_receiver import ThreadedDataServer, ThreadedDataHandler
 
 
 class VisualizerUI:
@@ -183,7 +182,7 @@ class VisualizerUI:
         self.layoutPixels()
         # self._master.after_idle(self.__handleResize)
 
-if __name__ == '__main__':
+def main():
     import argparse
     parser = argparse.ArgumentParser(description='BiblioPixel Visualizer')
     parser.add_argument('--width', help='Matrix Width',

--- a/bibliopixel/gamepad.py
+++ b/bibliopixel/gamepad.py
@@ -1,4 +1,4 @@
-from util import d
+from . util import d
 
 
 class BaseGamePad(object):

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -1,6 +1,11 @@
 import math, threading, time
 from . import colors, font
 
+try:
+    from tdsp import ColorList
+except:
+    ColorList = list
+
 class updateThread(threading.Thread):
 
     def __init__(self, driver):
@@ -50,8 +55,9 @@ class LEDBase(object):
 
         # This buffer will always be the same list - i.e. is guaranteed to only
         # be changed by list surgery, never assignment.
-        self._colors = []
+        self._colors = ColorList()
         self.all_off()
+        assert len(self._colors) == self.numLEDs
 
         self.masterBrightness = 255
 

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -49,7 +49,6 @@ class LEDBase(object):
             self.numLEDs = sum(d.numLEDs for d in self.driver)
 
         self.bufByteCount = int(3 * self.numLEDs)
-        self._last_i = self.lastIndex = self.numLEDs - 1
 
         # This buffer will always be the same list - i.e. is guaranteed to only
         # be changed by list surgery, never assignment.
@@ -84,14 +83,14 @@ class LEDBase(object):
         return self.__exit__(None, None, None)
 
     def _get_base(self, pixel):
-        if pixel < 0 or pixel > self.lastIndex:
+        if pixel < 0 or pixel >= self.numLEDs:
             return 0, 0, 0  # don't go out of bounds
 
         return (self.buffer[pixel * 3 + 0], self.buffer[pixel * 3 + 1], self.buffer[pixel * 3 + 2])
 
     def _set_base(self, pixel, color):
         try:
-            if pixel < 0 or pixel > self._last_i:
+            if pixel < 0 or pixel > self.numLEDs - 1:
                 raise IndexError()
 
             if self.masterBrightness < 255:
@@ -206,8 +205,8 @@ class LEDBase(object):
     def fill(self, color, start=0, end=-1):
         """Fill the entire strip with RGB color tuple"""
         start = max(start, 0)
-        if end < 0 or end > self.lastIndex:
-            end = self.lastIndex
+        if end < 0 or end >= self.numLEDs:
+            end = self.numLEDs - 1
         for led in range(start, end + 1):  # since 0-index include end in range
             self._set_base(led, color)
 
@@ -240,7 +239,6 @@ class LEDStrip(LEDBase):
         else:
             self.set = self._setScaled
             self.numLEDs = self.numLEDs / self.pixelWidth
-            self.lastIndex = self.numLEDs - 1
 
     # Set single pixel to Color value
     def _set(self, pixel, color):

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -73,6 +73,10 @@ class LEDBase(object):
 
         self.setMasterBrightness(masterBrightness)
 
+    def update(self):
+        """DEPRECATED."""
+        return self.push_to_driver()
+
     def __enter__(self):
         return self
 
@@ -117,7 +121,7 @@ class LEDBase(object):
         if self._waitingBrightness:
             self._doMasterBrigtness(self._waitingBrightnessValue)
 
-    def update(self):
+    def push_to_driver(self):
         """Push the current pixel state to the driver"""
         pos = 0
         self.waitForUpdate()
@@ -794,10 +798,10 @@ class LEDPOV(LEDMatrix):
         super(LEDPOV, self).__init__(driver, width, povHeight, None,
                                      rotation, vert_flip, threadedUpdate, masterBrightness)
 
-    # This is the magic. Overriding the normal update() method
+    # This is the magic. Overriding the normal push_to_driver() method
     # It will automatically break up the frame into columns spread over
     # frameTime (ms)
-    def update(self, frameTime=None):
+    def push_to_driver(self, frameTime=None):
         if frameTime:
             self._frameTotalTime = frameTime
 

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -813,9 +813,12 @@ class LEDPOV(LEDMatrix):
         for h in range(width):
             start = time.time() * 1000.0
 
-            buf = [item for sublist in [self._colors[(width * i * 3) + (h * 3):(
-                width * i * 3) + (h * 3) + (3)] for i in range(self.height)] for item in sublist]
-            self.driver[0].update(buf)
+            def color(i):
+                offset = (h + width * i) * 3
+                return self._colors[offset:offset + 3]
+            buf = [color(i) for i in range(self.height)]
+            buf = [item for sublist in buf for item in sublist]
+            self.driver[0].receive_colors(buf)
             sendTime = (time.time() * 1000.0) - start
             if sleep:
                 time.sleep(max(0, (sleep - sendTime) / 1000.0))

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -1,11 +1,6 @@
 import math, threading, time
 from . import colors, font
 
-try:
-    from tdsp import ColorList
-except:
-    ColorList = list
-
 class updateThread(threading.Thread):
 
     def __init__(self, driver):

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -1,6 +1,11 @@
 import math, threading, time
 from . import colors, font
 
+try:
+    from tdsp import ColorList
+except:
+    ColorList = list
+
 class updateThread(threading.Thread):
 
     def __init__(self, driver):

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -31,7 +31,7 @@ class updateThread(threading.Thread):
     def run(self):
         while not self.stopped():
             self._wait.wait()
-            self._driver._update(self._data)
+            self._driver.receive_colors(self._data)
             self._data = []
             self._wait.clear()
             self._reading.set()
@@ -134,7 +134,7 @@ class LEDBase(object):
             if self._threadedUpdate:
                 d._thread.setData(self._colors[pos:d.bufByteCount() + pos])
             else:
-                d._update(self._colors[pos:d.bufByteCount() + pos])
+                d.receive_colors(self._colors[pos:d.bufByteCount() + pos])
             pos += d.bufByteCount()
 
     def lastThreadedUpdate(self):

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -52,7 +52,8 @@ class LEDBase(object):
 
         # This buffer will always be the same list - i.e. is guaranteed to only
         # be changed by list surgery, never assignment.
-        self._colors = [0] * self.bufByteCount
+        self._colors = []
+        self.all_off()
 
         self.masterBrightness = 255
 
@@ -196,9 +197,6 @@ class LEDBase(object):
 
     def all_off(self):
         """Set all pixels off"""
-        self._resetBuffer()
-
-    def _resetBuffer(self):
         self._colors[:] = [0] * self.bufByteCount
 
     # Fill the strand (or a subset) with a single color using a Color object

--- a/bibliopixel/led.py
+++ b/bibliopixel/led.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python
-import colors
-import time
-import math
-import font
-import threading
-
+import math, threading, time
+from . import colors, font
 
 class updateThread(threading.Thread):
 

--- a/bibliopixel/serial_gamepad.py
+++ b/bibliopixel/serial_gamepad.py
@@ -6,7 +6,7 @@ except ImportError as e:
     raise ImportError(error)
 
 from distutils.version import LooseVersion
-from util import d
+from . util import d
 from gamepad import BaseGamePad
 import log
 

--- a/bibliopixel/win_gamepad_emu.py
+++ b/bibliopixel/win_gamepad_emu.py
@@ -1,7 +1,7 @@
 import win32api
 import win32con
 
-from util import d
+from . util import d
 from gamepad import BaseGamePad
 
 DEFAULT_MAP = {

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,0 +1,5 @@
+#!/bin/env/python
+
+if __name__ == '__main__':
+    from bibliopixel.drivers import visualizerUI
+    visualizerUI.main()


### PR DESCRIPTION
All right!

These are all pure Python changes to BiblioPixel to change the data representation of the buffers in led.py and friends from "lists of integers, conceptually divided into threes" into "list of triplets".

Note that I'm doing this review against v3.0 (which is now up-to-date with master).


I can do _some_ testing - mainly the visualizer - but not enough!

My solution to this - make tiny, self-contained changes as separate commits - so you can run the complete tests and if one of them breaks something, you can use git bisect to figure out which one - but more, so you can read each one in its entirety and believe that it's true.

The first nine commits should be non-breaking to clients no matter what.  The potentially breaking changes are in the last four, but I did preserve the original APIs - however, if you are reaching into `LEDBase._buffer` then you are going to get broken.

You should see some performance increases from these pure Python changes because I moved from creating new lists to updating existing lists.  Gosh, you love creating new lists.  :-D

Now, once this is done we should theoretically be able to drop in a `tdsp.ColorList` with no code changes at all, and get a further speed up, plus a bunch of improvements.  I'm almost wanting to try that now, but it's late here... 