### PR TITLE
[WIP] Pigpio spi

### DIFF
--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -1,19 +1,17 @@
-from . spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder, SpiPyDevInterface
 
 
 class DriverAPA102(DriverSPIBase):
     """Main driver for APA102 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True,
-                 dev="/dev/spidev0.0", SPISpeed=2, open=open):
-        super().__init__(num, c_order=c_order, use_py_spi=use_py_spi, dev=dev,
-                         SPISpeed=SPISpeed, open=open)
+    def __init__(self, num, c_order=ChannelOrder.RGB, **kwargs):
+        super(DriverAPA102, self).__init__(num, c_order=c_order, **kwargs)
 
         # APA102 requires latch bytes at the end
         self._latchBytes = (int(num / 64.0) + 1)
 
     def _render(self):
-        super()._render()
+        super(DriverAPA102, self)._render()
         newBuf = [0xFF] * (self.bufByteCount() + self.numLEDs)
         newBuf[1::4] = self._buf[0::3]
         newBuf[2::4] = self._buf[1::3]
@@ -71,10 +69,10 @@ MANIFEST = [
             "max": 24,
             "group": "Advanced"
         }, {
-            "id": "use_py_spi",
-            "label": "Use PySPI",
-            "type": "bool",
-            "default": True,
+            "id": "interface",
+            "label": "SPI interface",
+            "type": "class",
+            "default": SpiPyDevInterface,
             "group": "Advanced"
         }]
     }

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -1,6 +1,4 @@
-from .. import gamma
-
-from . spi_driver_base import DriverSPIBase, ChannelOrder
+from . spi_driver_base import DriverSPIBase, ChannelOrder, SpiPyDevInterface
 
 
 class DriverLPD8806(DriverSPIBase):
@@ -9,11 +7,8 @@ class DriverLPD8806(DriverSPIBase):
 
     def __init__(self, num,
                  c_order=ChannelOrder.RGB,
-                 use_py_spi=True,
-                 dev="/dev/spidev0.0",
-                 SPISpeed=2, open=open):
-        super().__init__(num, c_order=c_order, use_py_spi=use_py_spi, dev=dev,
-                         SPISpeed=SPISpeed, open=open, gamma=gamma.LPD8806)
+                 **kwargs):
+        super(DriverLPD8806, self).__init__(num, c_order=c_order, **kwargs)
 
         # LPD8806 requires latch bytes at the end
         self._latchBytes = (self.numLEDs + 31) // 32
@@ -73,10 +68,10 @@ MANIFEST = [
             "max": 24,
             "group": "Advanced"
         }, {
-            "id": "use_py_spi",
-            "label": "Use PySPI",
-            "type": "bool",
-            "default": True,
+            "id": "interface",
+            "label": "SPI interface",
+            "type": "class",
+            "default": SpiPyDevInterface,
             "group": "Advanced"
         }]
     }

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -1,18 +1,14 @@
-from . spi_driver_base import DriverSPIBase, ChannelOrder
-import os
-from .. import gamma
+from . spi_driver_base import DriverSPIBase, ChannelOrder, SpiPyDevInterface
 
 
 class DriverWS2801(DriverSPIBase):
     """Main driver for WS2801 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True,
-                 dev="/dev/spidev0.0", SPISpeed=1, open=open):
+    def __init__(self, num, c_order=ChannelOrder.RGB, SPISpeed=1, **kwargs):
         if SPISpeed > 1 or SPISpeed <= 0:
             raise ValueError(
                 "WS2801 requires an SPI speed no greater than 1MHz or SPI speed was set <= 0")
-        super().__init__(num, c_order=c_order, use_py_spi=use_py_spi, dev=dev,
-                         SPISpeed=SPISpeed, open=open, gamma=gamma.WS2801)
+        super(DriverWS2801, self).__init__(num, c_order=c_order, SPISpeed=SPISpeed, **kwargs)
 
 
 MANIFEST = [
@@ -56,10 +52,10 @@ MANIFEST = [
             "type": "str",
             "default": "/dev/spidev0.0",
         }, {
-            "id": "use_py_spi",
-            "label": "Use PySPI",
-            "type": "bool",
-            "default": True,
+            "id": "interface",
+            "label": "SPI interface",
+            "type": "class",
+            "default": SpiPyDevInterface,
             "group": "Advanced"
         }]
     }

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -30,18 +30,20 @@ class SpiBaseInterface(object):
 
 
 class SpiFileInterface(SpiBaseInterface):
+    """ using os open/write to send data"""
+
     def __init__(self, **kwargs):
         super(SpiFileInterface, self).__init__(**kwargs)
-        # File based SPI requires a bytearray so we have to overwrite _buf
-        self._buf = bytearray(self._buf)
         self.spi = open(self._dev, "wb")
 
     def send_packet(self, data):
-        self.spi.write(data)
+        self.spi.write(bytearray(data))
         self.spi.flush()
 
 
 class SpiPyDevInterface(SpiBaseInterface):
+    """ using py-spidev to send data"""
+
     def __init__(self, **kwargs):
         super(SpiPyDevInterface, self).__init__(**kwargs)
 
@@ -77,6 +79,10 @@ class SpiPyDevInterface(SpiBaseInterface):
 
 
 class SpiPiGpioInterface(SpiBaseInterface):
+    """ using pi gpio to send data
+        us this for the secound spi port on a raspberry pi
+        with dev=/dev/devspi1.0 """
+
     def __init__(self, **kwargs):
         super(SpiPiGpioInterface, self).__init__(**kwargs)
 
@@ -96,6 +102,7 @@ class SpiPiGpioInterface(SpiBaseInterface):
 
 class SpiDummyInterface(SpiBaseInterface):
     """ interface for testing proposal"""
+
     def __init__(self, **kwargs):
         super(SpiDummyInterface, self).__init__(**kwargs)
         pass

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -1,101 +1,111 @@
-from . driver_base import DriverBase, ChannelOrder
-import time
-
-import os
+from .driver_base import DriverBase, ChannelOrder
 from .. import log
 
 
-class SpiInterface(object):
-    FILE = 0
-    PY_SPI = 1
-    PI_GPIO = 2
+class SpiBaseInterface(object):
+    """ abstract class for different spi backends"""
+
+    def __init__(self, dev, SPISpeed):
+        self._dev = dev
+        self._spi_speed = SPISpeed
+        a, b = -1, -1
+        d = self._dev.replace("/dev/spidev", "")
+        s = d.split('.')
+        if len(s) == 2:
+            a = int(s[0])
+            b = int(s[1])
+        if a < 0 or b < 0:
+            error = "When using spi, the given device must be in the format /dev/spidev*.*"
+            log.error(error)
+            raise ValueError(error)
+
+        self._device_id = a
+        self._device_cs = b
+
+    def send_packet(self, data):
+        pass
+
+    def compute_packet(self, data):
+        return data
+
+
+class SpiFileInterface(SpiBaseInterface):
+    def __init__(self, **kwargs):
+        super(SpiFileInterface, self).__init__(**kwargs)
+        # File based SPI requires a bytearray so we have to overwrite _buf
+        self._buf = bytearray(self._buf)
+        self.spi = open(self._dev, "wb")
+
+    def send_packet(self, data):
+        self.spi.write(data)
+        self.spi.flush()
+
+
+class SpiPyDevInterface(SpiBaseInterface):
+    def __init__(self, **kwargs):
+        super(SpiPyDevInterface, self).__init__(**kwargs)
+
+        import os.path
+        try:
+            import spidev
+        except:
+            error = "Unable to import spidev. Please install. pip install spidev"
+            log.error(error)
+            raise ImportError(error)
+        if not os.path.exists(self._dev):
+            error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
+            log.error(error)
+            raise IOError(error)
+        # permissions check
+        try:
+            open(self._dev)
+        except IOError as e:
+            if e.errno == 13:
+                error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
+                log.error(error)
+                raise IOError(error)
+            else:
+                raise e
+        import spidev
+        self.spi = spidev.SpiDev()
+        self.spi.open(self._device_id, self._device_cs)
+        self.spi.max_speed_hz = int(self._spi_speed * 1000000.0)
+        log.info('py-spidev speed @ %.1f MHz', (float(self.spi.max_speed_hz) / 1000000.0))
+
+    def send_packet(self, data):
+        self.spi.xfer2(data)
+
+
+class SpiPiGpioInterface(SpiBaseInterface):
+    def __init__(self, **kwargs):
+        super(SpiPiGpioInterface, self).__init__(**kwargs)
+
+        AUX_SPI = (1 << 8)
+        try:
+            import pigpio
+        except:
+            error = "Unable to import pigpio. Please install. http://abyz.co.uk/rpi/pigpio/"
+            log.error(error)
+            raise ImportError(error)
+        self.pi = pigpio.pi()
+        self.spi = self.pi.spi_open(self._device_id, 50000, AUX_SPI)
+
+    def send_packet(self, data):
+        self.pi.spi_write(self.spi, data)
 
 
 class DriverSPIBase(DriverBase):
     """Base driver for controling SPI devices on systems like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.GRB, interface=SpiInterface.PY_SPI,
+    def __init__(self, num, c_order=ChannelOrder.GRB, interface=SpiPyDevInterface,
                  dev="/dev/spidev0.0", SPISpeed=2, open=open, gamma=None):
-        super(DriverSPIBase,self).__init__(num, c_order=c_order, gamma=gamma)
+        super(DriverSPIBase, self).__init__(num, c_order=c_order, gamma=gamma)
 
-        self.dev = dev
-        self.interface = interface
-        self._spiSpeed = SPISpeed
-
-        if self.interface == SpiInterface.PI_GPIO:
-            a, b = -1, -1
-            d = self.dev.replace("/dev/spidev", "")
-            s = d.split('.')
-            if len(s) == 2:
-                a = int(s[0])
-                b = int(s[1])
-            if a < 0 or b < 0:
-                error = "When using py-spidev, the given device must be in the format /dev/spidev*.*"
-                log.error(error)
-                raise ValueError(error)
-            AUX_SPI = (1 << 8)
-            import pigpio
-            self.pi = pigpio.pi()
-            self.spi = self.pi.spi_open(a, 50000, AUX_SPI)
-        elif self.interface == SpiInterface.PY_SPI:
-            a, b = -1, -1
-            d = self.dev.replace("/dev/spidev", "")
-            s = d.split('.')
-            if len(s) == 2:
-                a = int(s[0])
-                b = int(s[1])
-            if a < 0 or b < 0:
-                error = "When using py-spidev, the given device must be in the format /dev/spidev*.*"
-                log.error(error)
-                raise ValueError(error)
-            self._bootstrapPYSPIDev()
-            import spidev
-            self.spi = spidev.SpiDev()
-            self.spi.open(a, b)
-            self.spi.max_speed_hz = int(self._spiSpeed * 1000000.0)
-            log.info('py-spidev speed @ %.1f MHz',
-                     (float(self.spi.max_speed_hz) / 1000000.0))
-        elif self.interface == SpiInterface.FILE:
-            # File based SPI requires a bytearray so we have to overwrite _buf
-            self._buf = bytearray(self._buf)
-            self.spi = open(self.dev, "wb")
-        else:
-            raise ValueError('invalid interface')
-
-    def _bootstrapPYSPIDev(self):
-        import os.path
-        if self.interface == SpiInterface.PY_SPI:
-            try:
-                import spidev
-            except:
-                error = "Unable to import spidev. Please install. pip install spidev"
-                log.error(error)
-                raise ImportError(error)
-            if not os.path.exists(self.dev):
-                error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
-                log.error(error)
-                raise IOError(error)
-            # permissions check
-            try:
-                open(self.dev)
-            except IOError as e:
-                if e.errno == 13:
-                    error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
-                    log.error(error)
-                    raise IOError(error)
-                else:
-                    raise e
+        self.interface = interface(dev, SPISpeed)
 
     def _send_packet(self):
-        if self.interface == SpiInterface.PI_GPIO:
-            self.pi.spi_write(self.spi, self._packet)
-        elif self.interface == SpiInterface.PY_SPI:
-            self.spi.xfer2(self._packet)
-        elif self.interface == SpiInterface.FILE:
-            self.spi.write(self._packet)
-            self.spi.flush()
+        self.interface.send_packet(self._packet)
 
     def _compute_packet(self):
         self._render()
-        if self.interface is not SpiInterface.FILE:
-            self._packet = self._buf
+        self._packet = self.interface.compute_packet(self._buf)

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -94,11 +94,18 @@ class SpiPiGpioInterface(SpiBaseInterface):
         self.pi.spi_write(self.spi, data)
 
 
+class SpiDummyInterface(SpiBaseInterface):
+    """ interface for testing proposal"""
+    def __init__(self, **kwargs):
+        super(SpiDummyInterface, self).__init__(**kwargs)
+        pass
+
+
 class DriverSPIBase(DriverBase):
     """Base driver for controling SPI devices on systems like the Raspberry Pi and BeagleBone"""
 
     def __init__(self, num, c_order=ChannelOrder.GRB, interface=SpiPyDevInterface,
-                 dev="/dev/spidev0.0", SPISpeed=2, open=open, gamma=None):
+                 dev="/dev/spidev0.0", SPISpeed=2, gamma=None):
         super(DriverSPIBase, self).__init__(num, c_order=c_order, gamma=gamma)
 
         self.interface = interface(dev, SPISpeed)

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -108,7 +108,7 @@ class DriverSPIBase(DriverBase):
                  dev="/dev/spidev0.0", SPISpeed=2, gamma=None):
         super(DriverSPIBase, self).__init__(num, c_order=c_order, gamma=gamma)
 
-        self.interface = interface(dev, SPISpeed)
+        self.interface = interface(dev=dev, SPISpeed=SPISpeed)
 
     def _send_packet(self):
         self.interface.send_packet(self._packet)

--- a/bibliopixel/drivers/spi_driver_base.py
+++ b/bibliopixel/drivers/spi_driver_base.py
@@ -5,76 +5,97 @@ import os
 from .. import log
 
 
+class SpiInterface(object):
+    FILE = 0
+    PY_SPI = 1
+    PI_GPIO = 2
+
+
 class DriverSPIBase(DriverBase):
     """Base driver for controling SPI devices on systems like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.GRB, use_py_spi=True,
+    def __init__(self, num, c_order=ChannelOrder.GRB, interface=SpiInterface.PY_SPI,
                  dev="/dev/spidev0.0", SPISpeed=2, open=open, gamma=None):
-        super().__init__(num, c_order=c_order, gamma=gamma)
+        super(DriverSPIBase,self).__init__(num, c_order=c_order, gamma=gamma)
 
         self.dev = dev
-        self.use_py_spi = use_py_spi
+        self.interface = interface
         self._spiSpeed = SPISpeed
 
-        # File based SPI requires a bytearray so we have to overwrite _buf
-        if self.use_py_spi:
+        if self.interface == SpiInterface.PI_GPIO:
             a, b = -1, -1
             d = self.dev.replace("/dev/spidev", "")
             s = d.split('.')
             if len(s) == 2:
                 a = int(s[0])
                 b = int(s[1])
-
             if a < 0 or b < 0:
                 error = "When using py-spidev, the given device must be in the format /dev/spidev*.*"
                 log.error(error)
                 raise ValueError(error)
-
-            self._bootstrapSPIDev()
+            AUX_SPI = (1 << 8)
+            import pigpio
+            self.pi = pigpio.pi()
+            self.spi = self.pi.spi_open(a, 50000, AUX_SPI)
+        elif self.interface == SpiInterface.PY_SPI:
+            a, b = -1, -1
+            d = self.dev.replace("/dev/spidev", "")
+            s = d.split('.')
+            if len(s) == 2:
+                a = int(s[0])
+                b = int(s[1])
+            if a < 0 or b < 0:
+                error = "When using py-spidev, the given device must be in the format /dev/spidev*.*"
+                log.error(error)
+                raise ValueError(error)
+            self._bootstrapPYSPIDev()
             import spidev
             self.spi = spidev.SpiDev()
             self.spi.open(a, b)
             self.spi.max_speed_hz = int(self._spiSpeed * 1000000.0)
             log.info('py-spidev speed @ %.1f MHz',
                      (float(self.spi.max_speed_hz) / 1000000.0))
-        else:
+        elif self.interface == SpiInterface.FILE:
+            # File based SPI requires a bytearray so we have to overwrite _buf
             self._buf = bytearray(self._buf)
             self.spi = open(self.dev, "wb")
+        else:
+            raise ValueError('invalid interface')
 
-    def _bootstrapSPIDev(self):
+    def _bootstrapPYSPIDev(self):
         import os.path
-        import sys
-        if self.use_py_spi:
+        if self.interface == SpiInterface.PY_SPI:
             try:
                 import spidev
             except:
                 error = "Unable to import spidev. Please install. pip install spidev"
                 log.error(error)
                 raise ImportError(error)
-
-        if not os.path.exists(self.dev):
-            error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
-            log.error(error)
-            raise IOError(error)
-
-        # permissions check
-        try:
-            open(self.dev)
-        except IOError as e:
-            if e.errno == 13:
+            if not os.path.exists(self.dev):
                 error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
                 log.error(error)
                 raise IOError(error)
-            else:
-                raise e
+            # permissions check
+            try:
+                open(self.dev)
+            except IOError as e:
+                if e.errno == 13:
+                    error = "Cannot find SPI device. Please see https://github.com/maniacallabs/bibliopixel/wiki/SPI-Setup for details."
+                    log.error(error)
+                    raise IOError(error)
+                else:
+                    raise e
 
     def _send_packet(self):
-        if self.use_py_spi:
+        if self.interface == SpiInterface.PI_GPIO:
+            self.pi.spi_write(self.spi, self._packet)
+        elif self.interface == SpiInterface.PY_SPI:
             self.spi.xfer2(self._packet)
-        else:
+        elif self.interface == SpiInterface.FILE:
             self.spi.write(self._packet)
             self.spi.flush()
 
     def _compute_packet(self):
         self._render()
-        self._packet = self._buf
+        if self.interface is not SpiInterface.FILE:
+            self._packet = self._buf

--- a/test/driver_test.py
+++ b/test/driver_test.py
@@ -5,6 +5,7 @@ from bibliopixel.drivers.driver_base import DriverBase, ChannelOrder
 from bibliopixel.drivers.APA102 import DriverAPA102
 from bibliopixel.drivers.LPD8806 import DriverLPD8806
 from bibliopixel.drivers.WS2801 import DriverWS2801
+from bibliopixel.drivers.spi_driver_base import SpiDummyInterface
 
 from bibliopixel import timedata
 
@@ -23,7 +24,7 @@ class DriverTest(unittest.TestCase):
 
     ALL_COLORS = COLORS_PY, COLORS_TD
 
-    SPD = dict(use_py_spi=False, open=mock_open)
+    SPD = dict(interface=SpiDummyInterface)
 
     def do_test(self, driver, colors, expected):
         driver.set_colors(colors, 0)


### PR DESCRIPTION
This patch makes it possible to use use the python pigpio spi api.

Summery:
The newer Raspberry Pi's (>=2) have two SPI interfaces. But because of a driver issue the second interface is only available  with a other API.
I used for that PIGPIO http://abyz.co.uk/rpi/pigpio/.

Warning: as it currently only a bool is given to decide which interface should be use I switched to a enum based attribute.
This will probably causes in incompatible with older code.

The code is not tested, but open for discuses.
