### PR TITLE
spi_base rewrite

### DIFF
--- a/bibliopixel/drivers/APA102.py
+++ b/bibliopixel/drivers/APA102.py
@@ -5,10 +5,8 @@ from . spi_driver_base import DriverSPIBase
 class APA102(DriverSPIBase):
     """Main driver for APA102 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True,
-                 dev="/dev/spidev0.0", SPISpeed=2, open=open):
-        super().__init__(num, c_order=c_order, use_py_spi=use_py_spi, dev=dev,
-                         SPISpeed=SPISpeed, open=open)
+    def __init__(self, num, c_order=ChannelOrder.RGB, **kwargs):
+        super().__init__(num, c_order=c_order, **kwargs)
 
         # APA102 requires latch bytes at the end
         self._latchBytes = (int(num / 64.0) + 1)

--- a/bibliopixel/drivers/LPD8806.py
+++ b/bibliopixel/drivers/LPD8806.py
@@ -9,11 +9,8 @@ class LPD8806(DriverSPIBase):
 
     def __init__(self, num,
                  c_order=ChannelOrder.RGB,
-                 use_py_spi=True,
-                 dev="/dev/spidev0.0",
-                 SPISpeed=2, open=open):
-        super().__init__(num, c_order=c_order, use_py_spi=use_py_spi, dev=dev,
-                         SPISpeed=SPISpeed, open=open, gamma=gamma.LPD8806)
+                 spi_speed=2, gamma=gamma.LPD8806, **kwargs):
+        super().__init__(num, c_order=c_order, spi_speed=spi_speed, gamma=gamma, **kwargs)
 
         # LPD8806 requires latch bytes at the end
         self._latchBytes = (self.numLEDs + 31) // 32
@@ -35,23 +32,23 @@ MANIFEST = [
         "display": "LPD8806 (SPI Native)",
         "desc": "Interface with LPD8806 strips over a native SPI port (Pi, BeagleBone, etc.)",
         "params": [{
-                "id": "num",
-                "label": "# Pixels",
-                "type": "int",
-                "default": 1,
-                "min": 1,
-                "help": "Total pixels in display."
+            "id": "num",
+            "label": "# Pixels",
+            "type": "int",
+            "default": 1,
+            "min": 1,
+            "help": "Total pixels in display."
         }, {
             "id": "c_order",
             "label": "Channel Order",
             "type": "combo",
             "options": {
-                    0: "RGB",
-                    1: "RBG",
-                    2: "GRB",
-                    3: "GBR",
-                    4: "BRG",
-                    5: "BGR"
+                0: "RGB",
+                1: "RBG",
+                2: "GRB",
+                3: "GBR",
+                4: "BRG",
+                5: "BGR"
             },
             "options_map": [
                 [0, 1, 2],
@@ -74,12 +71,6 @@ MANIFEST = [
             "default": 2,
             "min": 1,
             "max": 24,
-            "group": "Advanced"
-        }, {
-            "id": "use_py_spi",
-            "label": "Use PySPI",
-            "type": "bool",
-            "default": True,
             "group": "Advanced"
         }]
     }

--- a/bibliopixel/drivers/WS2801.py
+++ b/bibliopixel/drivers/WS2801.py
@@ -1,19 +1,18 @@
 from . channel_order import ChannelOrder
 from . spi_driver_base import DriverSPIBase
-import os
 from .. import gamma
 
 
 class WS2801(DriverSPIBase):
     """Main driver for WS2801 based LED strips on devices like the Raspberry Pi and BeagleBone"""
 
-    def __init__(self, num, c_order=ChannelOrder.RGB, use_py_spi=True,
-                 dev="/dev/spidev0.0", SPISpeed=1, open=open):
-        if SPISpeed > 1 or SPISpeed <= 0:
+    def __init__(self, num, c_order=ChannelOrder.RGB,
+                 spi_speed=1, gamma=gamma.WS2801, **kwargs):
+        if spi_speed > 1 or spi_speed <= 0:
             raise ValueError(
                 "WS2801 requires an SPI speed no greater than 1MHz or SPI speed was set <= 0")
-        super().__init__(num, c_order=c_order, use_py_spi=use_py_spi, dev=dev,
-                         SPISpeed=SPISpeed, open=open, gamma=gamma.WS2801)
+        super().__init__(num, c_order=c_order, spi_speed=spi_speed,
+                         gamma=gamma, **kwargs)
 
 
 # This is DEPRECATED.
@@ -27,23 +26,23 @@ MANIFEST = [
         "display": "WS2801 (SPI Native)",
         "desc": "Interface with WS2801 strips over a native SPI port (Pi, BeagleBone, etc.)",
         "params": [{
-                "id": "num",
-                "label": "# Pixels",
-                "type": "int",
-                "default": 1,
-                "min": 1,
-                "help": "Total pixels in display."
+            "id": "num",
+            "label": "# Pixels",
+            "type": "int",
+            "default": 1,
+            "min": 1,
+            "help": "Total pixels in display."
         }, {
             "id": "c_order",
             "label": "Channel Order",
             "type": "combo",
             "options": {
-                    0: "RGB",
-                    1: "RBG",
-                    2: "GRB",
-                    3: "GBR",
-                    4: "BRG",
-                    5: "BGR"
+                0: "RGB",
+                1: "RBG",
+                2: "GRB",
+                3: "GBR",
+                4: "BRG",
+                5: "BGR"
             },
             "options_map": [
                 [0, 1, 2],
@@ -59,12 +58,6 @@ MANIFEST = [
             "label": "SPI Device Path",
             "type": "str",
             "default": "/dev/spidev0.0",
-        }, {
-            "id": "use_py_spi",
-            "label": "Use PySPI",
-            "type": "bool",
-            "default": True,
-            "group": "Advanced"
         }]
     }
 ]

--- a/bibliopixel/drivers/WS2812SPI.py
+++ b/bibliopixel/drivers/WS2812SPI.py
@@ -1,5 +1,6 @@
 from . spi_driver_base import DriverSPIBase, ChannelOrder
 from .. import gamma as _gamma
+from .. import log
 
 
 class WS281XSPI(DriverSPIBase):
@@ -9,7 +10,10 @@ class WS281XSPI(DriverSPIBase):
     """
 
     def __init__(self, num, **kwargs):
-        super().__init__(num, c_order=ChannelOrder.GRB, SPISpeed=3,
+        # WS281x need a base clock of ~1MHz with the encoding we need 3 times this clock
+        # After testing 3.2 looks like a good value
+        spi_speed = 3.2
+        super().__init__(num, c_order=ChannelOrder.GRB, spi_speed=spi_speed,
                          gamma=_gamma.WS2812, **kwargs)
 
     # WS2812 requires gamma correction so we run it through gamma as the
@@ -23,7 +27,7 @@ class WS281XSPI(DriverSPIBase):
 
         # buffer for result
         # [0] fixes, first led show green when should be off
-        buf2 = [0]
+        buf2 = bytearray([0])
         for byte in self._buf:
             # save each byte in an int var
             tmp = 0

--- a/test/driver_test.py
+++ b/test/driver_test.py
@@ -2,13 +2,10 @@ import unittest
 
 from bibliopixel import gamma
 from bibliopixel.drivers.driver_base import DriverBase, ChannelOrder
+from bibliopixel.drivers.spi_driver_base import SpiDummyInterface
 from bibliopixel.drivers.APA102 import APA102
 from bibliopixel.drivers.LPD8806 import LPD8806
 from bibliopixel.drivers.WS2801 import WS2801
-
-
-def mock_open(self, fname, perm='r'):
-    pass
 
 
 class DriverTest(unittest.TestCase):
@@ -17,7 +14,7 @@ class DriverTest(unittest.TestCase):
               (2, 16, 128),
               (3, 24, 192)]
 
-    SPD = dict(use_py_spi=False, open=mock_open)
+    SPD = dict(interface=SpiDummyInterface)
 
     def do_test(self, driver, expected):
         driver.set_colors(self.COLORS, 0)


### PR DESCRIPTION
Summery
-------------
This is a rewrite for the common used `spi_driver_base`.

main changes:
* remove `open` parameter - was for testing proposal only
* change `use_py_spi` to `interface`  -  use an object class instant of an bool
* use `**kwargs` in child drivers to have only one define expect different default values

This is only a cosmetic rewrite, IMHO it gets the code much clearer.

Result:
---------
### default case
should be equal
```python
from bibliopixel.drivers.LPD8806 import LPD8806
driver = LPD8806(42)
```


###  use file instant of pydev
old code
```python
from bibliopixel.drivers.LPD8806 import LPD8806
driver = LPD8806(42,use_py_spi=False)
```
new code
```python
from bibliopixel.drivers.LPD8806 import LPD8806
from bibliopixel.drivers.spi_driver_base import SpiFileInterface
driver = LPD8806(42, interface=SpiFileInterface)
```
###  testing
old code
```python
from bibliopixel.drivers.LPD8806 import LPD8806
def mock_open(...):
      ....
driver = LPD8806(42,open=mock_open)
```
new code
```python
from bibliopixel.drivers.LPD8806 import LPD8806
from bibliopixel.drivers.spi_driver_base import SpiDummyInterface
driver = LPD8806(42, interface=SpiDummyInterface)
```
Why
-----
I have done this for adding a additional interface which I don't need any more and is also not in the code. see pull request #64.
So this code was lying around and can now be tested.
I thought a new major release is the right time for that.

I also try to have a common way how parameters get inherited. Currently Parameters like `gamma`, `c_order` can sometime be changed in drivers like `LPD8806`. Have to think about that and one reason why work in progress.

Tested
--------
* orangepi Zero with `WS2812SPI` driver in `SpiFileInterface` and `SpiPyDevInterface` mode

more tests coming soon


Sorry for being a bit late, first the dev branch was a bit unstable to test my code, late I was short in time. Also oversee your last comment in that request.