### PR TITLE
last spi_base_driver improvements

### DIFF
--- a/bibliopixel/drivers/WS281X.py
+++ b/bibliopixel/drivers/WS281X.py
@@ -1,6 +1,5 @@
 from . spi_driver_base import DriverSPIBase, ChannelOrder
 from .. import gamma as _gamma
-from .. import log
 
 
 class WS281XSPI(DriverSPIBase):
@@ -9,10 +8,9 @@ class WS281XSPI(DriverSPIBase):
     Raspberry Pi, OrangePi, BeagleBone,..
     """
 
-    def __init__(self, num, **kwargs):
+    def __init__(self, num, spi_speed=3.2, **kwargs):
         # WS281x need a base clock of ~1MHz with the encoding we need 3 times this clock
-        # After testing 3.2 looks like a good value
-        spi_speed = 3.2
+        # After testing 3.0 to 3.2 looks like a good value
         super().__init__(num, c_order=ChannelOrder.GRB, spi_speed=spi_speed,
                          gamma=_gamma.WS2812, **kwargs)
 


### PR DESCRIPTION
Changes
=======
I found `python-periphery` as none c-lib SPI interface.
It works like `spidev` but need no gcc for installation. In my Opinio the better choose.

Periphery works like my ioctl hacks but has a bit better docu and some more features.
see https://github.com/vsergeev/python-periphery/blob/master/periphery/spi.py
(same magic number :). )
For that reason and keep code a bit shorter I reduce the `SpiFileInterface` backend to a minimum, in that case its a bit faster than periphery but speed argument is ignored!

At last I done some fixes from my last pull request
 * some copy paste misstakes in docu
 * rename WS2812SPI.py file to WS2812.py
 * add spi_speed argument in WS2812SPI driver

Notes
------
docu  periphery.spi https://python-periphery.readthedocs.io/en/latest/spi.html

TESTS
=====
Tests made with all backends (SpiPeripheryInterface, SpiPyDevInterface, SpiFileInterface).

WS2812SPI:
 * orangepi zero
 * raspbery pi 3
The needed clock is something between 3.0 to 3.2 different between opi and rpi.

LPD8066:
 * orangepi pc plus