### PR TITLE
Update README to point to Google Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 #### For usage details, check the [Wiki](https://github.com/ManiacalLabs/BiblioPixel/wiki)!
-#### If you still need support, please post on the [Forum](http://forum.maniacallabs.com)
+#### If you still need support, please post on the [BiblioPixel User Group](https://groups.google.com/forum/#!forum/bibliopixel-users)
 
 For easy hardware interfacing, check out the BiblioPixel supported [AllPixel](http://maniacallabs.com/AllPixel).
 
-Do you have an animation you would like to share? Submit to our [animation repository](https://github.com/ManiacalLabs/BiblioPixelAnimations) or post it to [our forum](http://forum.maniacallabs.com/forumdisplay.php?fid=6).
+Do you have an animation you would like to share? Submit to our [animation repository](https://github.com/ManiacalLabs/BiblioPixelAnimations) or post it to [our BiblioPixel User Group](https://groups.google.com/forum/#!forum/bibliopixel-users).
 
 Overview
 ====


### PR DESCRIPTION
Need to point to Google Group instead of forum which will be deprecated.