### PR TITLE
bugfix threading

### DIFF
--- a/bibliopixel/threads/animation_threading.py
+++ b/bibliopixel/threads/animation_threading.py
@@ -18,7 +18,7 @@ class AnimationThreading(object):
     def stop_thread(self, wait=False):
         if self.thread:
             self.stop_event.set()
-            if wait:
+            if wait and (threading.current_thread() != self.thread):
                 self.thread.join()
 
     def stopped(self):


### PR DESCRIPTION
When a Animation stops a exception is thrown
`RuntimeError: cannot join current thread`in 
https://github.com/ManiacalLabs/BiblioPixel/blob/master/bibliopixel/threads/animation_threading.py#L22

This happend because `Animation.cleanup()` has `wait=true`
https://github.com/ManiacalLabs/BiblioPixel/blob/master/bibliopixel/animation/animation.py#L30

This patch checks if the current thread is already the animation thread, if so do nothing.

full stacktrace:
```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "/home/light/venv/lib/python3.4/site-packages/bibliopixel/threads/animation_threading.py", line 30, in target
    self.run()
  File "/home/light/venv/lib/python3.4/site-packages/bibliopixel/animation/animation.py", line 95, in run_all_frames
    self.run_one_frame()
  File "/usr/lib/python3.4/contextlib.py", line 66, in __exit__
    next(self.gen)
  File "/home/light/venv/lib/python3.4/site-packages/bibliopixel/animation/animation.py", line 90, in run_context
    self.cleanup()
  File "/home/light/venv/lib/python3.4/site-packages/bibliopixel/animation/animation.py", line 30, in cleanup
    self.threading.stop_thread(wait=True)
  File "/home/light/venv/lib/python3.4/site-packages/bibliopixel/threads/animation_threading.py", line 22, in stop_thread
    self.thread.join()
  File "/usr/lib/python3.4/threading.py", line 1057, in join
    raise RuntimeError("cannot join current thread")
RuntimeError: cannot join current thread
```