### PR TITLE
Added coordMap option to Strip layout

### DIFF
--- a/bibliopixel/project/project.py
+++ b/bibliopixel/project/project.py
@@ -7,6 +7,7 @@ from .. layout.geometry import gen_matrix
 from .. layout.multimap import MultiMapBuilder
 from .. util import files
 from .. remote import control
+import copy
 
 
 def _make_object(*args, field_types=FIELD_TYPES, **kwds):
@@ -17,10 +18,12 @@ def _make_layout(layout, driver=None, drivers=None, maker=None):
     if driver is None and drivers is None:
         raise ValueError('Projects has no driver or drivers section')
 
+    _layout = copy.deepcopy(layout)
+    coord_map = _layout.get('coordMap', None)
+    _layout.pop('coordMap', None)
+
     if drivers is None:
         drivers = [_make_object(**driver)]
-        coord_map = None
-
     else:
         build = MultiMapBuilder()
 
@@ -33,10 +36,10 @@ def _make_layout(layout, driver=None, drivers=None, maker=None):
             drivers = [dict(driver, **d) for d in drivers]
 
         drivers = [make_driver(**d) for d in drivers]
-        coord_map = build.map
+        coord_map = coord_map or build.map
 
     maker = data_maker.Maker(**(maker or {}))
-    return _make_object(drivers, coordMap=coord_map, maker=maker, **layout)
+    return _make_object(drivers, coordMap=coord_map, maker=maker, **_layout)
 
 
 def make_animation(layout, animation, run=None):


### PR DESCRIPTION
While working on another project I realized that `Strip` lacked a `coordMap` option like the rest of the layouts. This may seem a bit odd for a `Strip` but in my case I needed to reverse the indices. It's also feasible to build a physical strip layout that is non-standard where you'd want to remap things. Probably stretching a bit, I just needed to reverse the strip but figured there was no reason for `Strip` not to have `coordMap` as well.

While I was at it, I noticed that while @rec added automatic generation of `coordMap` for multiple driver scenarios, it would error if you tried to pass a `coordMap` in from a project file. This is an absolute must. Eventually it would be nice to call out to the map generation functions from the project files but as custom coordinate maps are pretty much an advanced feature I'm ok with making it all nice to use later. For no, you can simply generate and export the coordMap list and then copy that into the json file.