### PR TITLE
Remote UI and various Fixups

### DIFF
--- a/bibliopixel/animation/animation.py
+++ b/bibliopixel/animation/animation.py
@@ -43,8 +43,8 @@ class BaseAnimation(object):
         else:
             self.state = STATE.running
 
-    def preRun(self, amt=1):
-        self.layout.all_off()
+    def pre_run(self):
+        pass
 
     def step(self, amt=1):
         raise RuntimeError("Base class step() called. This shouldn't happen")
@@ -119,7 +119,7 @@ class BaseAnimation(object):
 
         self.check_delay()
 
-        self.preRun(self.runner.amt)
+        self.pre_run()
         try:
             yield
         finally:

--- a/bibliopixel/animation/animation.py
+++ b/bibliopixel/animation/animation.py
@@ -68,11 +68,22 @@ class BaseAnimation(object):
             # Ingore STATE.complete if until_complete is False
             self.state = STATE.running
 
+    def check_delay(self):
+        if self.free_run:
+            self.sleep_time = None
+        elif self.internal_delay:
+            self.sleep_time = self.internal_delay
+        else:
+            self.sleep_time = self.runner.sleep_time
+        self.layout.animation_sleep_time = self.sleep_time or 0
+
     def run_one_frame(self):
         timestamps = []
 
         def stamp():
             timestamps.append(time.time())
+
+        self.check_delay()
 
         stamp()
 
@@ -106,13 +117,7 @@ class BaseAnimation(object):
         self.cur_step = 0
         self.cycle_count = 0
 
-        if self.free_run:
-            self.sleep_time = None
-        elif self.internal_delay:
-            self.sleep_time = self.internal_delay
-        else:
-            self.sleep_time = self.runner.sleep_time
-        self.layout.animation_sleep_time = self.sleep_time or 0
+        self.check_delay()
 
         self.preRun(self.runner.amt)
         try:

--- a/bibliopixel/animation/receiver.py
+++ b/bibliopixel/animation/receiver.py
@@ -35,8 +35,7 @@ class BaseReceiver(BaseAnimation):
         self._stop_event.clear()
         self._recv_thread_obj = None
 
-    def preRun(self, amt=1):
-        self.layout.all_off()
+    def pre_run(self):
         self.start()
 
     def start(self):

--- a/bibliopixel/animation/sequence.py
+++ b/bibliopixel/animation/sequence.py
@@ -31,7 +31,7 @@ class Sequence(animation.BaseAnimation):
         anim.set_runner(runner.Runner(**kwds))
         self.animations.append(anim)
 
-    def preRun(self, amt=1):
+    def pre_run(self):
         self.index = -1
 
     @property

--- a/bibliopixel/colors/wheel.py
+++ b/bibliopixel/colors/wheel.py
@@ -2,6 +2,7 @@ WHEEL_MAX = 384
 
 
 def _gen_wheel():
+    result = []
     for p in range(385):
         if p < 128:
             r = 127 - p % 128
@@ -15,8 +16,9 @@ def _gen_wheel():
             b = 127 - p % 128
             r = p % 128
             g = 0
+        result.append((r, g, b))
 
-    return r, g, b
+    return result
 
 
 _WHEEL = _gen_wheel()

--- a/bibliopixel/image.py
+++ b/bibliopixel/image.py
@@ -77,8 +77,10 @@ def loadImage(layout, imagePath="", imageObj=None, offset=(0, 0), bgcolor=colors
         if y >= 0 and x >= 0:
             texture[y][x] = pixel
 
-    return show_image(setter, layout.width, layout.height, imagePath, imageObj,
-                      offset, bgcolor, brightness)
+    show_image(setter, layout.width, layout.height, imagePath, imageObj,
+               offset, bgcolor, brightness)
+
+    return texture
 
 
 def convert_mode(image, mode='RGB'):

--- a/bibliopixel/matrix.py
+++ b/bibliopixel/matrix.py
@@ -370,7 +370,7 @@ def draw_char(fonts, setter, width, height, x, y, c, color, bg, aa=False, font=f
     fw = len(c_data)
     for i in range(fw + f['sep']):
         xPos = x + (i * font_scale)
-        if ((xPos < width) and (xPos + fw * font_scale - 1) >= 0) and (xPos >= 0):
+        if max(0, 1 - font_scale * fw) <= xPos < width:
             if i >= fw:
                 line = 0
             else:

--- a/bibliopixel/matrix.py
+++ b/bibliopixel/matrix.py
@@ -370,7 +370,7 @@ def draw_char(fonts, setter, width, height, x, y, c, color, bg, aa=False, font=f
     fw = len(c_data)
     for i in range(fw + f['sep']):
         xPos = x + (i * font_scale)
-        if ((xPos < width) and (xPos + fw * font_scale - 1) >= 0):
+        if ((xPos < width) and (xPos + fw * font_scale - 1) >= 0) and (xPos >= 0):
             if i >= fw:
                 line = 0
             else:

--- a/bibliopixel/project/project.py
+++ b/bibliopixel/project/project.py
@@ -66,9 +66,11 @@ def make_remote(layout, remote):
         anim_obj = dict(anim)
         try:
             anim_obj['animation'] = make_animation(layout, anim['animation'], run)
+            anim_obj['loaded'] = True
         except:
             log.error(traceback.format_exc())
             anim_obj['animation'] = None
+            anim_obj['loaded'] = False
         anim_obj.pop('run', None)  # no longer need this
         anim_list.append(anim_obj)
 

--- a/bibliopixel/project/project.py
+++ b/bibliopixel/project/project.py
@@ -8,6 +8,8 @@ from .. layout.multimap import MultiMapBuilder
 from .. util import files
 from .. remote import control
 import copy
+from .. import log
+import traceback
 
 
 def _make_object(*args, field_types=FIELD_TYPES, **kwds):
@@ -62,7 +64,11 @@ def make_remote(layout, remote):
         run = anim.get('run', {})
         run['threaded'] = True  # Remote anims must be threaded, maybe a little hacky?
         anim_obj = dict(anim)
-        anim_obj['animation'] = make_animation(layout, anim['animation'], run)
+        try:
+            anim_obj['animation'] = make_animation(layout, anim['animation'], run)
+        except:
+            log.error(traceback.format_exc())
+            anim_obj['animation'] = None
         anim_obj.pop('run', None)  # no longer need this
         anim_list.append(anim_obj)
 

--- a/bibliopixel/remote/control.py
+++ b/bibliopixel/remote/control.py
@@ -10,7 +10,8 @@ DEFAULT_OFF = 'OFF_ANIM'
 DEFAULT_ANIM_CONFIG = {
     'bgcolor': '#00ff00',
     'font_color': '#ffffff',
-    'display': None
+    'display': None,
+    'valid': True
 }
 
 DEFAULT_SERVER_CONFIG = {
@@ -57,10 +58,17 @@ class RemoteControl:
             anim_cfg = dict(DEFAULT_ANIM_CONFIG)
             anim_cfg.update(anim)
             if not anim_cfg['display']:
-                anim_cfg['display'] = anim['name']
+                anim_cfg['display'] = anim_cfg['name']
             anim_cfg['name'] = ''.join(e for e in anim['name'] if e.isalnum())
-            anim_cfg['animation'].on_completion = self.on_completion
-            self.animation_objs[anim_cfg['name']] = anim_cfg['animation']
+
+            if anim_cfg['animation'] is None:
+                anim_cfg['display'] = 'LOAD FAILED: ' + anim_cfg['display']
+                anim_cfg['valid'] = False
+                anim_cfg['bgcolor'] = 'rgb(16, 16, 16)'
+            else:
+                anim_cfg['animation'].on_completion = self.on_completion
+                self.animation_objs[anim_cfg['name']] = anim_cfg['animation']
+
             del anim_cfg['animation']  # no longer need here
             anim_list.append(anim_cfg)
         self.animations = anim_list

--- a/bibliopixel/remote/control.py
+++ b/bibliopixel/remote/control.py
@@ -61,15 +61,18 @@ class RemoteControl:
                 anim_cfg['display'] = anim_cfg['name']
             anim_cfg['name'] = ''.join(e for e in anim['name'] if e.isalnum())
 
-            if anim_cfg['animation'] is None:
-                anim_cfg['display'] = 'LOAD FAILED: ' + anim_cfg['display']
-                anim_cfg['valid'] = False
-                anim_cfg['bgcolor'] = 'rgb(16, 16, 16)'
-            else:
+            if anim_cfg['loaded']:
                 anim_cfg['animation'].on_completion = self.on_completion
                 self.animation_objs[anim_cfg['name']] = anim_cfg['animation']
+            else:
+                anim_cfg['display'] = 'LOAD FAILED: ' + anim_cfg['display']
+                anim_cfg['valid'] = False
+                anim_cfg['bgcolor'] = 'rgb(48, 48, 48)'
 
-            del anim_cfg['animation']  # no longer need here
+            # no longer need here
+            del anim_cfg['animation']
+            del anim_cfg['loaded']
+
             anim_list.append(anim_cfg)
         self.animations = anim_list
 

--- a/ui/web_remote/index.html
+++ b/ui/web_remote/index.html
@@ -30,7 +30,7 @@
 <body class='loading'>
     <div id='overlay'><p id='overlay_text'>Testing</p></div>
     <div id='main_body'>
-        <div id='Title'></div>
+        <div id='title'></div>
         <div id='button_list'>
         </div>
     </div>

--- a/ui/web_remote/main.js
+++ b/ui/web_remote/main.js
@@ -55,7 +55,7 @@ function hide_btn_loading(id){
     $('#' + id).html(display);
 }
 
-function add_button(config, click_func){
+function add_button(config, click_func, dest='#button_list'){
     var div = document.createElement('div');
     div.className = 'btn';
     div.style.background = config.bgcolor;
@@ -68,7 +68,7 @@ function add_button(config, click_func){
             click_func(config.name, $(this).attr('id'))
         });
     }
-    $('#button_list').append(div);
+    $(dest).append(div);
 }
 
 function do_main(){
@@ -78,7 +78,7 @@ function do_main(){
 
             document.body.style.background = config.ui.bgcolor;
             document.body.style.color = config.ui.font_color;
-            $('#Title').text(config.ui.title);
+            $('#title').text(config.ui.title);
             document.title = config.ui.title;
             add_button(STOP_CONFIG, stop_animation);
             for(i=0; i < config.animations.length; i++){

--- a/ui/web_remote/main.js
+++ b/ui/web_remote/main.js
@@ -42,7 +42,8 @@ var STOP_CONFIG =       {
     'bgcolor': '#ff0000',
     'display': 'STOP',
     'font_color': '#ffffff',
-    'name': 'OFF_ANIM'
+    'name': 'OFF_ANIM',
+    'valid': true
 };
 
 function show_btn_loading(id){
@@ -62,9 +63,11 @@ function add_button(config, click_func){
     $(div).html(config.display);
     $(div).attr('display', config.display);
     div.id = 'button_' + config.name;
-    div.addEventListener('click', function(){
-        click_func(config.name, $(this).attr('id'))
-    });
+    if(config.valid){
+        div.addEventListener('click', function(){
+            click_func(config.name, $(this).attr('id'))
+        });
+    }
     $('#button_list').append(div);
 }
 


### PR DESCRIPTION
I fixed and tweaked a whole bunch of things while going through all of BPA and making sure everything actually worked... it was bad. So much was broken, but it should all fix now. And the BPA repo has project json files for strip, matrix, cube, and circle containing nearly all animations.
See https://github.com/ManiacalLabs/BiblioPixelAnimations/pull/24 for more on that.

But here's the highlights:

- preRun amt param is no more. It was not used anywhere and was just plain silly. GONE.
- internal_delay was broken because it was supposed to check and adjust every frame but it only checked in run_context(). As usual, all that will probably go away eventually anyways, but this was a feature of BP2 that was broken in BP3, so it got fixed. Totally screwed up ImageAnim, among others.
- gen_wheel() function was broken
- loadImage() returned nothing, breaking the image animations. Now correctly returns image data.
- Fixed a *long* standing ScrollText bug where the text would wrap into negative indices and show up on the wrong side of the display.
- Exceptions while loading an animation in make_remote() no longer crash the whole load. This was problematic because if I send you a project file and you are missing a dependency the whole thing craps out and you have to figure out installing the dependency. This was a no-go for the aforementioned project files added to BPA. We needed as much of it to load as possible and just disable the rest. On that note:
- Animations that fail to load still get a button in the remote, but it's disabled and prepended with "LOAD FAILED:". The log still gets the exception. I may need to go back and wrap that bit in the code that nicely prints out how to install the dependency. Though this also covers non-import animation load failures.
- 