### PR TITLE
Remote UI Triggers

### DIFF
--- a/bibliopixel/project/project.py
+++ b/bibliopixel/project/project.py
@@ -15,14 +15,15 @@ Your path was %s."""
 def make_animation(layout, animation, run=None):
     animation = aliases.resolve(animation)
     reserved = {p: animation.pop(p, None) for p in RESERVED_PROPERTIES}
-    animation = importer.make_object(layout, **animation)
+    animation_obj = importer.make_object(layout, **animation)
 
     # Add the reserved properties back in.
     for k, v in reserved.items():
-        (v is not None) and setattr(animation, k, v)
+        animation[k] = v
+        (v is not None) and setattr(animation_obj, k, v)
 
-    animation.set_runner(run)
-    return animation
+    animation_obj.set_runner(run)
+    return animation_obj
 
 
 def extend_path(path):

--- a/bibliopixel/remote/server.py
+++ b/bibliopixel/remote/server.py
@@ -1,5 +1,6 @@
 import logging, os, queue, sys
 from .. util import log
+import flask
 
 MESSAGE = """\
 Remote UI Server available at: {1}
@@ -17,7 +18,6 @@ class RemoteServer:
         cdir = os.path.dirname(os.path.realpath(__file__))
         static_dir = os.path.abspath(os.path.join(cdir, '../../ui/web_remote'))
 
-        import flask
         self.app = flask.Flask('BP Remote', static_folder=static_dir)
 
         self._set_routes()
@@ -45,14 +45,13 @@ class RemoteServer:
         return self.api('stop_animation')
 
     def api(self, request, data=None):
-        self.q_send.put({'req': request.lower(), 'data': data})
+        self.q_send.put({'req': request.lower(), 'data': data, 'sender': 'RemoteServer'})
 
         try:
             status, data = self.q_recv.get(timeout=5)
         except queue.Empty:
             status, data = False, 'Timeout waiting for response.'
 
-        import flask
         return flask.jsonify({
             'status': status,
             'msg': 'OK' if status else data,

--- a/bibliopixel/remote/trigger.py
+++ b/bibliopixel/remote/trigger.py
@@ -1,0 +1,10 @@
+from .. util import importer
+
+
+class TriggerBase:
+    def __init__(self, q, configs):
+        self.q = q
+        self.configs = configs
+
+    def trigger(self, name):
+        self.q.put({'req': 'trigger_animation', 'data': name, 'sender': 'Trigger'})

--- a/bibliopixel/remote/trigger_process.py
+++ b/bibliopixel/remote/trigger_process.py
@@ -1,0 +1,10 @@
+from .. util import importer
+
+
+def run_trigger(typename, q, configs):
+    trigger_class = importer.import_symbol(typename)
+    trigger = trigger_class(q, configs)
+    try:
+        trigger.start()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
I fully expect a few semantic quibbles here, but the code works and is sound.
First note that you need to clone and install this: https://github.com/ManiacalLabs/BiblioPixelTriggers
That includes what is currently the only available trigger, `crontab`, and I intend to update BP to install BPT by default. BPT, however, will NOT install any dependencies except for `croniter` used by `crontab` as it's simple and I want `crontab` to be always available. When I add more triggers like Bluetooth proximity, I will of course just have it gracefully fail and tell you how to install the dependencies. This is why I actually import the module once first in control.py and then later in trigger_process.py - I want it to fail before it would fail inside a new process.

On that note... The remote animation now takes a `triggers` param like this:
```
 "triggers": [
            {
                "typename": "BiblioPixelTriggers.crontab.crontab",
                "config": "*/2 * * * *",
                "name": "Bloom"
            },
            {
                "typename": "BiblioPixelTriggers.crontab.crontab",
                "config": "1-59/2 * * * *",
                "name": "OFF_ANIM"
            }
        ]
```
The Remote animation, however, will create only a single process for each *type* of trigger, `crontab` in this instance. The reason for this layout is to have one entry per trigger, even if there are multiple triggers that are all the same type. This decreases the total possible depth of the `triggers` dict. But what I do is bundle all config/name pair for each trigger type and pass them as a list to that trigger class. So that trigger type gets one process and one class instance and it's expected to handle that list of config/name pairs appropriately.

One thing I need to resolve is aliases for the trigger typename... though maybe not. Since triggers live in a different repo and PyPi package we'd have to keep things in sync, which I'd rather not.

I probably should also do that little hack that makes a module become a sub-object... basically `BiblioPixel.crontab` instead of `BiblioPixel.crontab.crontab`... need to look up how to do that again. But that would at least decrease typename length.


Demo project file (GitHub would not let me attach a json file for some reason).
This will run Bloom on even minutes and OFF_ANIM (which is MatrixRain in this case) on odd minutes. `crontab` supports everything that actual `crontab` does. I was going to make my own kind of close version, but then found `croniter` and got lazy, deciding that this was perfect for what I needed.
```
{
    "animation": {
        "title": "Trigger Demo",
        "typename": "remote",
        "animations": [
            {
                "animation": {
                    "typename": "BiblioPixelAnimations.matrix.MatrixRain.MatrixRain",
                    "name": "MatrixRain"
                },
                "run": {
                    "fps": 30
                }
            },
            {
                "animation": {
                    "typename": "BiblioPixelAnimations.matrix.bloom.Bloom",
                    "name": "Bloom"
                },
                "run": {
                    "fps": 30,
                    "amt": 6
                }
            },
            {
                "animation": {
                    "typename": "BiblioPixelAnimations.matrix.perlin_simplex.PerlinSimplex",
                    "name": "PerlinSimplex"
                },
                "run": {
                    "fps": 30
                }
            }
        ],
        "default": "MatrixRain",
        "bgcolor": "black",
        "external_access": true,
        "port": 5000,
        "triggers": [
            {
                "typename": "BiblioPixelTriggers.crontab.crontab",
                "config": "*/2 * * * *",
                "name": "Bloom"
            },
            {
                "typename": "BiblioPixelTriggers.crontab.crontab",
                "config": "1-59/2 * * * *",
                "name": "OFF_ANIM"
            }
        ]
    },
    "driver": {
        "num": 1024,
        "typename": "simpixel"
    },
    "layout": {
        "typename": "matrix",
        "width": 32,
        "height": 32
    }
}
```