### PR TITLE
Re-arranged trigger configs

### DIFF
--- a/bibliopixel/remote/trigger.py
+++ b/bibliopixel/remote/trigger.py
@@ -2,9 +2,9 @@ from .. util import importer
 
 
 class TriggerBase:
-    def __init__(self, q, configs):
+    def __init__(self, q, events):
         self.q = q
-        self.configs = configs
+        self.events = events
 
     def trigger(self, name):
         self.q.put({'req': 'trigger_animation', 'data': name, 'sender': 'Trigger'})

--- a/bibliopixel/remote/trigger_process.py
+++ b/bibliopixel/remote/trigger_process.py
@@ -1,9 +1,9 @@
 from .. util import importer
 
 
-def run_trigger(typename, q, configs):
+def run_trigger(typename, q, events, kwargs):
     trigger_class = importer.import_symbol(typename)
-    trigger = trigger_class(q, configs)
+    trigger = trigger_class(q, events, **kwargs)
     try:
         trigger.start()
     except KeyboardInterrupt:


### PR DESCRIPTION
When I went to add a solar (sunrise, dusk, etc) trigger I realized that my attempt to prevent yet another dict level was more annoying than helpful. Say, for example, I wanted to have animations trigger at dawn, dusk, and night, I would have to enter the lat & lon for my location for each of those entries. And have typename 3 times. It was less annoying with crontab since there was only a single option. But I can definitely see options where multiple triggers share many of the same base config options.

So, now trigger configs look like this:
```
"triggers": [
            {
                "typename": "BiblioPixelTriggers.crontab.crontab",
                "events": [
                    {
                        "config": "*/2 * * * *",
                        "name": "Bloom"
                    },
                    {
                        "config": "1-59/2 * * * *",
                        "name": "OFF_ANIM"
                    }
                ]

            }
            {
                "typename": "BiblioPixelTriggers.solar.solar",
                "lat": 35.684732,
                "lon":-78.765541,
                "events": [
                    {
                        "config": "dusk",
                        "name": "Bloom"
                    },
                    {
                        "config": "dawn",
                        "name": "OFF_ANIM"
                    }
                ]

            }
        ]
```

Note, you will need the latest BiblioPixelTriggers installed of course.
I also added the ability to pass generic **kwargs, which is how things like `lat` and `lon` are handled.