### PR TITLE
Collection/Sequence could start next before dying

### DIFF
--- a/bibliopixel/animation/collection.py
+++ b/bibliopixel/animation/collection.py
@@ -13,6 +13,7 @@ class Collection(animation.BaseAnimation):
 
     # Override to handle all the animations
     def cleanup(self, clean_layout=True):
+        self.state = animation.STATE.canceled
         for a in self.animations:
             if a:
                 a.cleanup()


### PR DESCRIPTION
@rec This was a fun one to figure out. When connected to a display that's a little slow to setup, a sequence had a non-zero chance that when cleanup() was called, the animation would loop back around again and start the next animation before completely dying. It then put it into a state of weirdness where you could not kill it anymore because it thought it was already dead. I put the fix in collection because this will and should affect anything that derives from collection. When cleanup is called, state should always be set so nothing else happens.

