### PR TITLE
[WIP] Switching to yaml parser and better error parsing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 htmlcov
 .eggs
 .cache
+.pytest_cache

--- a/bibliopixel/main/run.py
+++ b/bibliopixel/main/run.py
@@ -62,7 +62,6 @@ def _get_projects(args):
                 root_file = None
             else:
                 desc = load.data(filename, False)
-                desc = json.loads(desc, filename)
                 root_file = os.path.abspath(filename)
 
             project = common_flags.make_project(args, desc, root_file)

--- a/bibliopixel/project/load.py
+++ b/bibliopixel/project/load.py
@@ -12,8 +12,9 @@ def data(name, use_json=True):
         return {}
 
     try:
-        return json.loads(name)
+        return json.load(name)
     except:
+        raise
         return loady.data.load(name, use_json)
 
 

--- a/projects/33-bloom.yaml
+++ b/projects/33-bloom.yaml
@@ -1,0 +1,4 @@
+animation: BiblioPixelAnimations.matrix.bloom.Bloom
+run:
+  seconds: 2
+  fps: 30

--- a/test/bibliopixel/project/bad_project_test.py
+++ b/test/bibliopixel/project/bad_project_test.py
@@ -83,7 +83,7 @@ class BadProjectTest(unittest.TestCase):
 
         self.assertEquals(
             e.exception.args[0::2],
-            ('There was a error in the data file',
+            ('There was an error in the data file',
              'Expecting value: line 1 column 1 (char 0)'))
 
     def test_cant_open(self):


### PR DESCRIPTION
Switched over to full time yaml parsing (even for JSON).

@rec - Primarily I'm putting this up here for you to play with it. You are more familiar with the errors we'd expect so I want you to try to break this :P

Also, I cannot get the tests to run on Windows (hangs on sub_test) so I'm being lazy and letting Travis do it for now.

One note is that this makes it a little more forgiving of JSON. For example:

```
{
    "animation": "BiblioPixelAnimations.matrix.bloom.Bloom",
    "run": {
        "seconds": 2,
        "fps": 30
        "test"
    }
}
```

Will work fine. BP bitches about `test` not being valid for Bloom, but it still runs.
Removing one of the curly braces however and...
```
 bp run .\projects\33-bloom.json
INFO - data_maker - Using numpy
ERROR - run - 1 project failed
____________________

ERROR - run - When reading file .\projects\33-bloom.json:
(not loaded)

There was an error in the data file
.\projects\33-bloom.json
while parsing a flow mapping
  in ".\projects\33-bloom.json", line 1, column 1:
    {
    ^
expected ',' or '}', but got '<stream end>'
  in ".\projects\33-bloom.json", line 8, column 1:

    ^

ERROR: Run aborted
```