### PR TITLE
Fix device id set

### DIFF
--- a/bibliopixel/drivers/serial/io.py
+++ b/bibliopixel/drivers/serial/io.py
@@ -6,7 +6,7 @@ from ... util import log, util
 def send_packet(cmd, size, dev, baudrate, timeout, more_data=None):
     packet = util.generate_header(cmd, size)
     if more_data:
-        packet += more_data
+        packet.append(more_data)
 
     com = serial.Serial(dev, baudrate=baudrate, timeout=timeout)
     com.write(packet)


### PR DESCRIPTION
@rec - Reported by someone on the ML facebook page.
I've confirmed this code was only used by device ID set and there's little chance it ever worked. `+=` doesn't  really work with bytearrays. This sets it back to the way it's always done data packet building and confirmed works.