### PR TITLE
Use mido multi_receive instead of MultiPort to receive midi messages

### DIFF
--- a/bibliopixel/control/midi.py
+++ b/bibliopixel/control/midi.py
@@ -77,7 +77,7 @@ class Midi(control.ExtractedLoop):
         port_names = ', '.join('"%s"' % p.name for p in ports)
         log.info('Starting to listen for MIDI on port%s %s',
                  '' if len(ports) == 1 else 's', port_names)
-        for port, msg in mido.ports.MultiPort(ports, yield_ports=True):
+        for port, msg in mido.ports.multi_receive(ports, yield_ports=True):
             mdict = dict(vars(msg), port=port)
 
             if self.use_note_off:

--- a/test/bibliopixel/control/midi_test.py
+++ b/test/bibliopixel/control/midi_test.py
@@ -22,7 +22,7 @@ class FakeMido:
                 return msgs
 
         self.ports = self
-        self.ports.MultiPort = multi_port
+        self.ports.multi_receive = multi_port
 
     def get_input_names(self):
         class Port(str):


### PR DESCRIPTION
I tested on Raspberry Pi & Windows and in both cases MultiPort would not yield midi messages, however multi_receive works perfectly.

p.s. I would open up an issue on mido but the dev seems to be inactive there.