### PR TITLE
Preserve stack traces of exceptions

### DIFF
--- a/bibliopixel/animation/indexed.py
+++ b/bibliopixel/animation/indexed.py
@@ -52,10 +52,10 @@ class Indexed(Collection):
             return True
         except StopIteration:
             pass
-        except Exception as e:
+        except Exception:
             if self.fail_on_exception:
                 raise
-            log.error('Exception %s in wrapper.step()', e)
+            log.exception('Exception in wrapper.step()')
 
     def forward(self, *unused):
         self.index += 1

--- a/bibliopixel/builder/runner.py
+++ b/bibliopixel/builder/runner.py
@@ -38,8 +38,7 @@ class Runner:
             try:
                 self.thread and self.thread.stop()
             except:
-                log.error('Error stopping thread')
-                traceback.print_exc()
+                log.exception('Error stopping thread')
             self.thread = None
             return True
 

--- a/bibliopixel/drivers/serial/driver.py
+++ b/bibliopixel/drivers/serial/driver.py
@@ -169,22 +169,22 @@ class Serial(DriverBase):
     def _close(self):
         try:
             return self._com and self._com.close()
-        except Exception as e:
-            log.error('Serial exception %s in close', e)
+        except Exception:
+            log.exception('Serial exception in close')
         finally:
             self._com = None
 
     def _write(self, packet):
         try:
             return self._com and self._com.write(packet)
-        except Exception as e:
-            log.error('Serial exception %s in write', e)
+        except Exception:
+            log.exception('Serial exception in write')
 
     def _flushInput(self):
         try:
             return self._com and self._com.flushInput()
-        except Exception as e:
-            log.error('Serial exception %s in flushInput', e)
+        except Exception:
+            log.exception('Serial exception in flushInput')
 
 
 class TeensySmartMatrix(Serial):

--- a/bibliopixel/drivers/serial/io.py
+++ b/bibliopixel/drivers/serial/io.py
@@ -20,5 +20,5 @@ def read_byte(com):
         resp = com.read(1)
         if resp:
             return ord(resp)
-    except Exception as e:
-        log.error('Serial exception %s in read', e)
+    except Exception:
+        log.exception('Serial exception in read')

--- a/bibliopixel/project/edit_queue.py
+++ b/bibliopixel/project/edit_queue.py
@@ -54,5 +54,4 @@ class EditQueue(queue.Queue):
             try:
                 e()
             except:
-                log.error('Error on edit %s', e)
-                traceback.print_exc()
+                log.exception('Error on edit %s', e)

--- a/bibliopixel/project/fill.py
+++ b/bibliopixel/project/fill.py
@@ -65,7 +65,7 @@ def _fill_palettes(desc):
             try:
                 palettes.set_default(default)
             except:
-                log.error('Unable to set default palette to be %s', default)
+                log.exception('Unable to set default palette to be %s', default)
     return desc
 
 

--- a/bibliopixel/project/project_runner.py
+++ b/bibliopixel/project/project_runner.py
@@ -62,10 +62,10 @@ def run(args):
             log.warning('\nKeyboardInterrupt terminated project.')
             needs_pause = False
 
-        except Exception as e:
+        except Exception:
             if not args.ignore_exceptions:
                 raise
-            log.error('Exception %s', e)
+            log.exception('Exception')
             traceback.print_exc()
 
 

--- a/bibliopixel/util/image/extract_gif_lines.py
+++ b/bibliopixel/util/image/extract_gif_lines.py
@@ -15,7 +15,7 @@ def extract_gif_lines(lines):
         try:
             project = data_file.loads(codelines)
         except:
-            log.error('Unable to load code: $s\n%s', filename, codelines)
+            log.exception('Unable to load code: $s\n%s', filename, codelines)
         else:
             yield filename, project
 

--- a/bibliopixel/util/log.py
+++ b/bibliopixel/util/log.py
@@ -137,8 +137,8 @@ def is_debug():
 _addLoggingLevel('FRAME', FRAME)
 logger = _new_custom_logger()
 
-frame, debug, info, warning, error = (
-    logger.frame, logger.debug, logger.info, logger.warning, logger.error)
+frame, debug, info, warning, error, exception = (
+    logger.frame, logger.debug, logger.info, logger.warning, logger.error, logger.exception)
 
 
 # The function `printer` emits text no matter what the loglevel, and without any

--- a/bibliopixel/util/pid_context.py
+++ b/bibliopixel/util/pid_context.py
@@ -31,9 +31,9 @@ def pid_context(pid_filename=None):
     finally:
         try:
             os.remove(pid_filename)
-        except Exception as e:
-            log.error('Got an exception %s deleting the pid_filename %s',
-                      e, pid_filename)
+        except Exception:
+            log.exception('Got an exception deleting the pid_filename %s',
+                          pid_filename)
 
 
 def get_pid(pid_filename=None):

--- a/bibliopixel/util/threads/runnable.py
+++ b/bibliopixel/util/threads/runnable.py
@@ -93,8 +93,7 @@ class Runnable:
             while self.running:
                 self.run_once()
         except:
-            log.error('Exception at %s: \n%s',
-                      str(self), traceback.format_exc())
+            log.exception('Exception at %s:', str(self))
         finally:
             self.stop()
             self.cleanup()

--- a/bibliopixel/util/udp.py
+++ b/bibliopixel/util/udp.py
@@ -89,8 +89,8 @@ class Receiver(runnable.LoopThread):
         super().stop()
         try:
             self.socket.close()
-        except Exception as e:
-            log.error('Exception in socket.close: %s', e)
+        except Exception:
+            log.exception('Exception in socket.close')
 
 
 class QueuedReceiver(Receiver):

--- a/scripts/documentation/extract-gifs
+++ b/scripts/documentation/extract-gifs
@@ -91,7 +91,7 @@ def extract_one_gif(args, filename, desc):
     except KeyboardInterrupt:
         raise
     except:
-        log.error('Error in project %s', filename)
+        log.exception('Error in project %s', filename)
         try:
             os.remove(str(path))
         except:
@@ -99,8 +99,6 @@ def extract_one_gif(args, filename, desc):
 
         if args.fail:
             raise
-        else:
-            traceback.print_exc()
 
 
 def extract(args):


### PR DESCRIPTION
Addresses #1151 

Preserve stack traces of exceptions.

This is very important for people who are writing their own animations to make debugging possible.

Example error messages:

Before:
```
ERROR - indexed - Exception 'Palette' object has no attribute 'batch_apply_palette' in wrapper.step()
```

After:
```
ERROR - indexed - Exception in wrapper.step()
Traceback (most recent call last):
  File "/home/pi/workspace/wonderdomicile/BiblioPixel/bibliopixel/animation/indexed.py", line 51, in step
    next(self.frames)
  File "/home/pi/workspace/wonderdomicile/BiblioPixel/bibliopixel/animation/animation.py", line 150, in generate_frames
    self._run_one_frame()
  File "/home/pi/workspace/wonderdomicile/BiblioPixel/bibliopixel/animation/animation.py", line 164, in _run_one_frame
    self.step(self.runner.amt)
  File "./animations/colorwave.py", line 46, in step
    colors = self.palette.batch_apply_palette(vals)
AttributeError: 'Palette' object has no attribute 'batch_apply_palette'
```