### PR TITLE
Fix for the change to the namespace in the dependant PMW library wrap…

### DIFF
--- a/bibliopixel/drivers/PiWS281X.py
+++ b/bibliopixel/drivers/PiWS281X.py
@@ -31,7 +31,7 @@ The PiWS281X driver needs to be run as sudo.  Rerun it with sudo, like this:
 """
 
 try:
-    from neopixel import Adafruit_NeoPixel, Color as NeoColor
+    from rpi_ws281x import Adafruit_NeoPixel, Color as NeoColor
 except:
     NeoColor = None
 


### PR DESCRIPTION
Namespace changed as discussed on the forum this evening and tested  OK on my RPi Zero W.