### PR TITLE
Update legacy_palette.py

### DIFF
--- a/bibliopixel/colors/legacy_palette.py
+++ b/bibliopixel/colors/legacy_palette.py
@@ -1,5 +1,5 @@
 from . import make
-
+from . import palette
 
 def pop_legacy_palette(kwds, *color_defaults):
     """
@@ -9,15 +9,5 @@ def pop_legacy_palette(kwds, *color_defaults):
     This function mutates a kwds dictionary to remove these legacy fields and
     extract a palette from it, which it returns.
  """
-    palette = kwds.pop('palette', None)
-    if palette:
-        legacy = [k for k, _ in color_defaults if k in kwds]
-        if legacy:
-            raise ValueError('Cannot set palette and ' + ', '.join(legacy))
-        return palette
-
-    values = [kwds.pop(k, v) for k, v in color_defaults]
-    if values and color_defaults[0][0] in ('colors', 'palette'):
-        values = values[0]
-
-    return make.colors(values or None)
+    new_palette = kwds.pop('palette', None)
+    return palette.Palette(colors = new_palette)


### PR DESCRIPTION
if statements and returning make.colors('palette', None) throws error. Constructing a palette object and returning it will do. 
Requiring the palette to be declared with kwds and then removing the kwds is redundant and causes errors as values that have been removed cannot be returned.